### PR TITLE
Use API for download statistics

### DIFF
--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -99,7 +99,7 @@ const index: React.FC<Props> = (props: Props) => {
             });
             const msfs_package_dir = settings.get('mainSettings.msfsPackagePath');
 
-            const fetchResp = await fetch(track.url);
+            const fetchResp = await fetch("https://api.flybywiresim.com/api/v1/download?url=" + track.url, { redirect: "follow" });
             console.log("Starting Download");
 
             const respReader = fetchResp.body.getReader();


### PR DESCRIPTION
Fixes #20 

## Summary of Changes
Use our statistics service for all downloads. The service sends a 302 with the correct URL. The download itself is not done through this service and still uses the CDN.

## Screenshots (if necessary)


## Additional context
Service is running and tested. It only allows and counts URLs prefixed with `https://flybywiresim-packages.nyc3.cdn.digitaloceanspaces.com`


Discord username (if different from GitHub): nistei#1362
