### PR TITLE
Now deletes folder before unzipping new file

### DIFF
--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -157,6 +157,10 @@ const index: React.FC<Props> = (props: Props) => {
             if (typeof msfs_package_dir === "string") {
                 const zipFile = new Zip(compressedBuffer);
 
+                if (fs.existsSync(msfs_package_dir + props.mod.key)) {
+                    fs.rmdirSync(msfs_package_dir + props.mod.key, { recursive: true });
+                }
+
                 zipFile.extractAllTo(msfs_package_dir);
             }
             dispatch(updateDownloadProgress(props.mod.name, 0));


### PR DESCRIPTION
<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #29

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Deletes the a32nx folder before unzipping the new installed file. 

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
