### PR TITLE
feat: add windows notification when download complete

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,7 @@
 1. [UI] Do not allow text selection - @FoxtrotSierra6829 (Foxtrot Sierra#6420)
 1. [UI] Do not allow image dragging - @FoxtrotSierra6829 (Foxtrot Sierra#6420)
 1. [LOGIC] Do not allow preselecting different version while downloading - @FoxtrotSierra6829 (Foxtrot Sierra#6420)
+1. [UX] Add Windows notification when download complete - @FoxtrotSierra6829 (Foxtrot Sierra#6420)
 
 ## 1.0.3
 

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -336,11 +336,15 @@ const index: React.FC<Props> = (props: Props) => {
     }
 
     function notifyDownload() {
-        Notification.requestPermission().then(function () {
-            new Notification('Download complete!', {
-                'body': "You're ready to fly",
+        try {
+            Notification.requestPermission().then(function () {
+                new Notification('Download complete!', {
+                    'body': "You're ready to fly",
+                });
             });
-        });
+        } catch (e) {
+            console.log(e);
+        }
     }
 
     function handleFindInstalledTrack() {

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -336,15 +336,11 @@ const index: React.FC<Props> = (props: Props) => {
     }
 
     function notifyDownload() {
-        try {
-            Notification.requestPermission().then(function () {
-                new Notification('Download complete!', {
-                    'body': "You're ready to fly",
-                });
+        Notification.requestPermission().then(function () {
+            new Notification('Download complete!', {
+                'body': "You're ready to fly",
             });
-        } catch (e) {
-            console.log(e);
-        }
+        }).catch(e => console.log(e));
     }
 
     function handleFindInstalledTrack() {

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -294,6 +294,7 @@ const index: React.FC<Props> = (props: Props) => {
                         settings.set('cache.' + props.mod.key + '.lastInstalledTrack', track.name);
 
                         console.log("Download complete!");
+                        notifyDownload();
                     } else {
                         setInstalledStateText('Failed');
                         setTimeout(() => setInstalledStateText(''), 3_000);
@@ -332,6 +333,14 @@ const index: React.FC<Props> = (props: Props) => {
             controller.abort();
             dispatch(deleteDownload(props.mod.name));
         }
+    }
+
+    function notifyDownload() {
+        Notification.requestPermission().then(function () {
+            new Notification('Download complete!', {
+                'body': "You're ready to fly",
+            });
+        });
     }
 
     function handleFindInstalledTrack() {


### PR DESCRIPTION
Fixes #79


## Summary of Changes
Windows Notification is displayed when the download and install process is completed.

## Screenshots (if necessary)
![Screenshot (1244)](https://user-images.githubusercontent.com/50082450/105929280-8bd70080-6047-11eb-95cd-ecac3d7c3720.png)


## Additional context
Currently there is no option to disable it, as considered in #79, but since it just goes away after some seconds (it's not permanent in notification center), I don't really see the need.
About the icon: there isn't really much we can do about it. It's using the partly transparent icon from the application and adds the windows theme color as a layer below it. Hopefully gets fixed in future Windows versions, just like in the start menu.

Discord username (if different from GitHub):
Foxtrot Sierra#6420
