### PR TITLE
Updates active/hover appearance

### DIFF
--- a/src/renderer/components/AircraftSection/TrackSelector.tsx
+++ b/src/renderer/components/AircraftSection/TrackSelector.tsx
@@ -54,7 +54,28 @@ export const Track = styled(BaseTrack)`
 
   cursor: pointer;
   
-  border: ${props => props.isSelected ? `solid ${colors.title} 2px` : 'solid transparent 2px'};
+  //border: ${props => props.isSelected ? `solid ${colors.title} 2px` : 'solid transparent 2px'};
+  //border: solid transparent 2px;
+  :after {
+    content:'';
+    position: absolute;
+    top: ${props => props.isSelected ? '10% !important' : 'calc(50% - 5px)'};
+    left: 0;
+    width: 5px;
+    height: ${props => props.isSelected ? '80% !important' : '10px'};
+    background-color: ${colors.cardSelected};
+    border-top-right-radius: 5px;
+    border-bottom-right-radius: 5px;
+    transition-property: height, top;
+    transition-duration: .1s;
+  }
+  
+  &:hover:after {
+    top: calc(50% - 10px);
+    height: 20px;
+  }
+  
+  
 `;
 
 const TrackTitle = styled.h5`

--- a/src/renderer/components/AircraftSection/TrackSelector.tsx
+++ b/src/renderer/components/AircraftSection/TrackSelector.tsx
@@ -73,8 +73,6 @@ export const Track = styled(BaseTrack)`
     top: calc(50% - 10px);
     height: 20px;
   }
-  
-  
 `;
 
 const TrackTitle = styled.h5`

--- a/src/renderer/components/AircraftSection/TrackSelector.tsx
+++ b/src/renderer/components/AircraftSection/TrackSelector.tsx
@@ -18,6 +18,7 @@ type TrackProps = {
     className?: string,
     track: ModTrack,
     isSelected: boolean,
+    isInstalled: boolean,
     // eslint-disable-next-line no-unused-vars
     onSelected(track: ModTrack): void,
 };
@@ -54,18 +55,16 @@ export const Track = styled(BaseTrack)`
 
   cursor: pointer;
   
-  //border: ${props => props.isSelected ? `solid ${colors.title} 2px` : 'solid transparent 2px'};
-  //border: solid transparent 2px;
   :after {
     content:'';
     position: absolute;
-    top: ${props => props.isSelected ? '10% !important' : 'calc(50% - 5px)'};
+    top: ${props => props.isSelected ? '0% !important' : 'calc(50% - 5px)'};
     left: 0;
-    width: 5px;
-    height: ${props => props.isSelected ? '80% !important' : '10px'};
-    background-color: ${colors.cardSelected};
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    width: ${props => props.isSelected ? '10px' : '5px'};
+    height: ${props => props.isSelected ? '100% !important' : '10px'};
+    border-left: 5px solid;
+    border-color: ${props => props.isInstalled ? colors.cardInstalled : colors.cardSelected};
+    border-radius: 5px;
     transition-property: height, top;
     transition-duration: .1s;
   }

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -56,6 +56,7 @@ const UpdateReasonMessages = {
 const index: React.FC<Props> = (props: Props) => {
     const [selectedVariant] = useState<ModVariant>(props.mod.variants[0]);
     const [selectedTrack, setSelectedTrack] = useState<ModTrack>(handleFindInstalledTrack());
+    const [installedTrack, setInstalledTrack] = useState<ModTrack>(handleFindInstalledTrack());
     const [needsUpdate, setNeedsUpdate] = useState<boolean>(false);
     const [needsUpdateReason, setNeedsUpdateReason] = useState<string>();
     const [changeVersion, setChangeVersion] = useState<boolean>(false);
@@ -282,6 +283,7 @@ const index: React.FC<Props> = (props: Props) => {
 
                         // Set states
                         setIsInstalled(true);
+                        setInstalledTrack(track);
                         setNeedsUpdate(false);
 
                         // Flash completion text
@@ -426,7 +428,7 @@ const index: React.FC<Props> = (props: Props) => {
                         <Tracks>
                             {
                                 selectedVariant.tracks.filter(track => !track.isExperimental).map(track =>
-                                    <Track key={track.key} track={track} isSelected={selectedTrack === track} onSelected={track => findAndSetTrack(track.key)} />
+                                    <Track key={track.key} track={track} isSelected={selectedTrack === track} isInstalled={installedTrack === track} onSelected={track => findAndSetTrack(track.key)} />
                                 )
                             }
                         </Tracks>
@@ -436,7 +438,7 @@ const index: React.FC<Props> = (props: Props) => {
                         <Tracks>
                             {
                                 selectedVariant.tracks.filter(track => track.isExperimental).map(track =>
-                                    <Track key={track.key} track={track} isSelected={selectedTrack === track} onSelected={track => findAndSetTrack(track.key)} />
+                                    <Track key={track.key} track={track} isSelected={selectedTrack === track} isInstalled={installedTrack === track} onSelected={track => findAndSetTrack(track.key)} />
                                 )
                             }
                         </Tracks>

--- a/src/renderer/style/theme.ts
+++ b/src/renderer/style/theme.ts
@@ -19,7 +19,7 @@ export const colors = {
     cardBackground: '#313131',
     cardBackgroundHover: '#3b3b3b',
     cardForeground: '#FFFFFFDD',
-    cardSelected: '#01C2CB',
+    cardSelected: '#00C2CB',
     cardInstalled: '#2E995E'
 };
 

--- a/src/renderer/style/theme.ts
+++ b/src/renderer/style/theme.ts
@@ -19,6 +19,7 @@ export const colors = {
     cardBackground: '#313131',
     cardBackgroundHover: '#3b3b3b',
     cardForeground: '#FFFFFFDD',
+    cardSelected: '#01C2CB',
 };
 
 export const dropShadow = css`

--- a/src/renderer/style/theme.ts
+++ b/src/renderer/style/theme.ts
@@ -20,6 +20,7 @@ export const colors = {
     cardBackgroundHover: '#3b3b3b',
     cardForeground: '#FFFFFFDD',
     cardSelected: '#01C2CB',
+    cardInstalled: '#2E995E'
 };
 
 export const dropShadow = css`


### PR DESCRIPTION
Fixes #57 

## Summary of Changes
Updates the hover/active apperances of the version selection. This is an alternative/updated suggestion to PR #111 

## Screenshots (if necessary)
![image](https://fbw.soler.dev/tmp/mM5aNs179c.gif)
(Framerate of gif is a bit low)

## Additional context
Not sure if the aircraft selection A32NX/A380X requires the same for now.

Discord username (if different from GitHub): Th3Alchemist#2043