### PR TITLE
fix: button styling in settings menu

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,6 +12,7 @@
 1. [LOGIC] Do not allow preselecting different version while downloading - @FoxtrotSierra6829 (Foxtrot Sierra#6420)
 1. [UX] Add Windows notification when download complete - @FoxtrotSierra6829 (Foxtrot Sierra#6420)
 1. [UX] Add changelog for installer - @FoxtrotSierra6829 (Foxtrot Sierra#6420)
+1. [UI] Fix button styling in settings menu - @FoxtrotSierra6829 (Foxtrot Sierra#6420)
 
 ## 1.0.3
 

--- a/src/renderer/components/GeneralSettings/index.tsx
+++ b/src/renderer/components/GeneralSettings/index.tsx
@@ -5,14 +5,13 @@ import { setupInstallPath } from 'renderer/actions/install-path.utils';
 import {
     Container,
     PageTitle,
-    SettingButton,
     SettingItemContent,
     SettingItemName,
     SettingsItem,
-    SettingsItems
+    SettingsItems,
+    InfoContainer,
+    InfoButton
 } from './styles';
-import styled from "styled-components";
-import { colors } from "renderer/style/theme";
 import { configureInitialInstallPath } from "renderer/settings";
 
 const settings = new Store;
@@ -30,27 +29,10 @@ function InstallPathSettingItem(props: { path: string, setPath: (path: string) =
     return (
         <SettingsItem>
             <SettingItemName>Install Directory</SettingItemName>
-            <SettingItemContent>{props.path}</SettingItemContent>
-            <SettingButton onClick={handleClick}>Modify</SettingButton>
+            <SettingItemContent onClick={handleClick}>{props.path}</SettingItemContent>
         </SettingsItem>
     );
 }
-
-const InfoContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  
-  padding-right: .55em;
-`;
-
-const InfoItem = styled.h6`
-  margin-top: 1.5em;
-  color: ${colors.mutedText} !important;
-  
-  cursor: pointer;
-`;
 
 function index(): JSX.Element {
     const [installPath, setInstallPath] = useState<string>(settings.get('mainSettings.msfsPackagePath') as string);
@@ -69,8 +51,8 @@ function index(): JSX.Element {
                 </SettingsItems>
             </Container>
             <InfoContainer>
-                <InfoItem onClick={showchangelog}>{settings.get('metaInfo.currentVersion')}</InfoItem>
-                <InfoItem onClick={handleReset}>Reset</InfoItem>
+                <InfoButton onClick={showchangelog}>{settings.get('metaInfo.currentVersion')}</InfoButton>
+                <InfoButton onClick={handleReset}>Reset</InfoButton>
             </InfoContainer>
         </>
     );

--- a/src/renderer/components/GeneralSettings/styles.tsx
+++ b/src/renderer/components/GeneralSettings/styles.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Button } from 'antd';
 import styled from 'styled-components';
+import { colors } from "renderer/style/theme";
 
 export const Container = styled.div`
     display: flex;
@@ -35,11 +36,39 @@ export const SettingItemName = styled.span`
 export const SettingItemContent = styled.span`
     width: 80%;
     font-size: 15px;
-    color: #bfbfbf;
+    color: ${colors.mutedText} !important;
     margin-bottom: 15px;
     white-space: wrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    cursor: pointer;
+
+    :hover {
+      color: ${colors.mutedTextDark} !important;
+    }
+`;
+
+export const InfoContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  
+  padding-right: .55em;
+`;
+
+export const InfoItem = styled.h6`
+  margin-top: 1.5em;
+  color: ${colors.mutedText} !important;
+`;
+export const InfoButton = styled.h6`
+  margin-top: 1.5em;
+  color: ${colors.mutedText} !important;
+  cursor: pointer;
+
+  :hover {
+    color: ${colors.mutedTextDark} !important;
+  }
 `;
 
 export const SettingButton = styled((props) => <Button type="link" style={{ color: '#41a4ff' }} {...props}>{props.children}</Button>)``;


### PR DESCRIPTION
Fixes #97 

## Summary of Changes
- buttons now hover dark
- removed Modify button, as it was styled and positioned awkwardly. Functionality is now kept by the install folder declaration.
- refactor code

## Screenshots (if necessary)
Before
![grafik](https://user-images.githubusercontent.com/50082450/106831527-5d34d780-6690-11eb-9f5a-5eb1eb6b5464.png)

After
![grafik](https://user-images.githubusercontent.com/50082450/106831549-69209980-6690-11eb-8ebc-8c7e90e20a87.png)

Discord username (if different from GitHub):
Foxtrot Sierra#6420
