### PR TITLE
feat: added issue creation button

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,6 +12,7 @@
 1. [LOGIC] Do not allow preselecting different version while downloading - @FoxtrotSierra6829 (Foxtrot Sierra#6420)
 1. [UX] Add Windows notification when download complete - @FoxtrotSierra6829 (Foxtrot Sierra#6420)
 1. [UX] Add changelog for installer - @FoxtrotSierra6829 (Foxtrot Sierra#6420)
+1. [UX] Add report issue button at top right corner of installer - @Armankir (Arman#5297)
 
 ## 1.0.3
 

--- a/src/renderer/components/WindowActionButtons/index.tsx
+++ b/src/renderer/components/WindowActionButtons/index.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
-import { BorderOutlined, CloseOutlined, MinusOutlined } from '@ant-design/icons';
+import { BorderOutlined, CloseOutlined, MinusOutlined, ExclamationCircleOutlined } from '@ant-design/icons';
 import { Button, Container } from './styles';
 import InstallerUpdate from '../InstallerUpdate';
+import { shell } from 'electron';
 
 function index(): JSX.Element {
+
+    const openGithub = () => shell.openExternal("https://github.com/flybywiresim/a32nx/issues/new/choose");
+
     return (
         <Container>
             <InstallerUpdate />
+            <Button onClick={openGithub} ><ExclamationCircleOutlined /></Button>
             <Button id="min-button"><MinusOutlined /></Button>
             <Button id="max-button"><BorderOutlined /></Button>
             <Button id="close-button" isClose><CloseOutlined /></Button>


### PR DESCRIPTION
Co-Authored-By: ZigTag <17077422+ZigTag@users.noreply.github.com>

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #108 

## Summary of Changes
We added a report issue button at the top right corner of the installer, the button will open the A32NX issue report page on GitHub.

## Screenshots (if necessary)
![Capture](https://user-images.githubusercontent.com/70278701/106991792-fa514800-6744-11eb-965f-62071e1729f7.PNG)

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Arman#5297
