### PR TITLE
fix: reset version being 'lost' on reset

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,7 +3,6 @@ import * as fs from 'fs';
 import * as readLine from 'readline';
 import Store from 'electron-store';
 import walk from 'walkdir';
-import * as packageInfo from '../../package.json';
 import installExtension, { REDUX_DEVTOOLS, REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer';
 declare const MAIN_WINDOW_WEBPACK_ENTRY: never;
 
@@ -140,10 +139,6 @@ app.on('second-instance', () => {
 // code. You can also put them in separate files and import them here.
 
 function configureSettings(app: App) {
-    // Store the current version
-    const version = packageInfo.version;
-    settings.set('metaInfo.currentVersion', version);
-
     if (!settings.has('mainSettings.msfsPackagePath')) {
         let userPath = null;
 

--- a/src/renderer/components/GeneralSettings/index.tsx
+++ b/src/renderer/components/GeneralSettings/index.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import store from '../../redux/store';
 import Store from 'electron-store';
 import { setupInstallPath } from 'renderer/actions/install-path.utils';
+import * as packageInfo from '../../../../package.json';
 import {
     Container,
     PageTitle,
@@ -39,6 +40,8 @@ function index(): JSX.Element {
 
     const handleReset = async () => {
         settings.clear();
+        const version = packageInfo.version;
+        settings.set('metaInfo.currentVersion', version);
         setInstallPath(await configureInitialInstallPath());
     };
 

--- a/src/renderer/components/GeneralSettings/index.tsx
+++ b/src/renderer/components/GeneralSettings/index.tsx
@@ -40,8 +40,6 @@ function index(): JSX.Element {
 
     const handleReset = async () => {
         settings.clear();
-        const version = packageInfo.version;
-        settings.set('metaInfo.currentVersion', version);
         setInstallPath(await configureInitialInstallPath());
     };
 
@@ -54,7 +52,7 @@ function index(): JSX.Element {
                 </SettingsItems>
             </Container>
             <InfoContainer>
-                <InfoButton onClick={showchangelog}>{settings.get('metaInfo.currentVersion')}</InfoButton>
+                <InfoButton onClick={showchangelog}>{packageInfo.version}</InfoButton>
                 <ResetButton onClick={handleReset}>Reset settings to default</ResetButton>
             </InfoContainer>
         </>


### PR DESCRIPTION
<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
- After reset, the installer version was not displayed anymore until a restart. Fixed.

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
Foxtrot Sierra#6420
