### PR TITLE
fix: no cleanup after abort

### DIFF
--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -244,21 +244,17 @@ const index: React.FC<Props> = (props: Props) => {
         } catch (e) {
             if (signal.aborted) {
                 setInstallStatus(InstallStatus.DownloadCanceled);
-                setTimeout(async () => setInstallStatus(await getInstallStatus()), 3_000);
-                return;
+            } else {
+                console.error(e);
+                setInstallStatus(InstallStatus.DownloadError);
             }
-
-            console.error(e);
-
-            // Flash error text
-            setInstallStatus(InstallStatus.DownloadError);
-            setTimeout(async () => setInstallStatus(await getInstallStatus()), 3_000);
-
-            dispatch(deleteDownload(props.mod.name));
-        } finally {
-            // Clean up temp dir
-            fs.rmdirSync(tempDir, { recursive: true });
         }
+
+        setTimeout(async () => setInstallStatus(await getInstallStatus()), 3_000);
+        dispatch(deleteDownload(props.mod.name));
+
+        // Clean up temp dir
+        fs.rmdirSync(tempDir, { recursive: true });
     };
 
     const selectAndSetTrack = async (key: string) => {


### PR DESCRIPTION
## Summary of Changes
Fix cleanup of temporary directory when aborting a download

## Screenshots (if necessary)
N/A

## Additional context
N/A

Discord username (if different from GitHub): nistei#1362
