### PR TITLE
change tempdir to OS default

### DIFF
--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -38,7 +38,7 @@ import { Version, Versions } from "renderer/components/AircraftSection/VersionHi
 import { Track, Tracks } from "renderer/components/AircraftSection/TrackSelector";
 import { install, needsUpdate, getCurrentInstall } from "@flybywiresim/fragmenter";
 import * as path from 'path';
-import { remote } from 'electron';
+import os from 'os';
 
 const settings = new Store;
 
@@ -76,7 +76,7 @@ const index: React.FC<Props> = (props: Props) => {
     };
 
     const getTempDir = (): string => {
-        return path.join(remote.app.getPath('temp'), 'flybywire_installer');
+        return path.join(os.tmpdir(), 'flybywire_installer');
     };
 
     const findInstalledTrack = (): ModTrack => {

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -37,7 +37,8 @@ import _ from 'lodash';
 import { Version, Versions } from "renderer/components/AircraftSection/VersionHistory";
 import { Track, Tracks } from "renderer/components/AircraftSection/TrackSelector";
 import { install, needsUpdate, getCurrentInstall } from "@flybywiresim/fragmenter";
-import * as path from "path";
+import * as path from 'path';
+import { remote } from 'electron';
 
 const settings = new Store;
 
@@ -75,7 +76,7 @@ const index: React.FC<Props> = (props: Props) => {
     };
 
     const getTempDir = (): string => {
-        return path.join(settings.get('mainSettings.msfsPackagePath') as string, `${props.mod.targetDirectory}-temp`);
+        return path.join(remote.app.getPath('temp'), 'flybywire_installer');
     };
 
     const findInstalledTrack = (): ModTrack => {


### PR DESCRIPTION
<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
change tempdir to '%temp%/flybywire_installer'
**!Important to prevent loading issues with MSFS**
(No, '%temp%/flybywire/current_install' does not work somehow, no clue why path.join() fails in all variants to do so)
## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
Foxtrot Sierra#6420
