### PR TITLE
build: use new CDN for installer distribution

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,6 +49,7 @@ jobs:
       - name: Upload to Bunny CDN
         env:
           BUNNY_BUCKET_PASSWORD: ${{ secrets.BUNNY_BUCKET_PASSWORD }}
+          BUNNY_SECRET_TOKEN: ${{ secrets.BUNNY_SECRET_TOKEN }}
         run: ./scripts/cdn.sh out/make/squirrel.windows/x64 installer/stable
 
       - name: Upload to DigitalOcean CDN

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,12 @@ jobs:
           asset_name: ${{ env.ASSET_NAME }}
           asset_content_type: application/x-msdos-program
 
-      - name: Upload to CDN
+      - name: Upload to Bunny CDN
+        env:
+          BUNNY_BUCKET_PASSWORD: ${{ secrets.BUNNY_BUCKET_PASSWORD }}
+        run: ./scripts/cdn.sh out/make/squirrel.windows/x64 installer/stable
+
+      - name: Upload to DigitalOcean CDN
         run: |
           mkdir -p ~/.aws
           touch ~/.aws/credentials

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
             "setupExe": "setup.exe",
             "iconUrl": "https://cdn.flybywiresim.com/assets/installer/icon.ico",
             "loadingGif": "./src/main/icons/loading.gif",
-            "remoteReleases": "https://flybywiresim-packages.nyc3.digitaloceanspaces.com/installer"
+            "remoteReleases": "https://cdn.flybywiresim.com/installer/stable"
           }
         }
       ],

--- a/scripts/cdn.sh
+++ b/scripts/cdn.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 CDN_URL="storage.bunnycdn.com/flybywiresim"
+CDN_PURGE_LINK="https://bunnycdn.com/api/purge?url=http://flybywiresim.b-cdn.net"
 FILES=${1}
 CDN_DIR=${2:-"installer/test"}
 
@@ -12,5 +13,13 @@ for FILE in "${FILES}"/*; do
     echo "Syncing file: $FILE"
     echo "Destination: $DEST"
     curl -X PUT -H "AccessKey: $BUNNY_BUCKET_PASSWORD" --data-binary "@$FILE" "$DEST"
-    echo ""; echo ""
+done
+
+# Purge after all uploads that the files are somewhat in sync
+echo "Purging cache"
+for FILE in "${FILES}"/*; do
+    DEST="$CDN_PURGE_LINK/$CDN_DIR/$(basename -- "$FILE")"
+    echo "Purging cache for file: $FILE"
+    echo "Purge URL: $DEST"
+    curl -X POST -H "AccessKey: $BUNNY_SECRET_TOKEN" -H "Content-Length: 0" "$DEST"
 done

--- a/scripts/cdn.sh
+++ b/scripts/cdn.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+CDN_URL="storage.bunnycdn.com/flybywiresim"
+FILES=${1}
+CDN_DIR=${2:-"installer/test"}
+
+echo "Syncing files from: ${FILES}/*"
+echo "Syncing to: ${CDN_DIR}"
+
+for FILE in "${FILES}"/*; do
+    DEST="$CDN_URL/$CDN_DIR/$(basename -- "$FILE")"
+    echo "Syncing file: $FILE"
+    echo "Destination: $DEST"
+    curl -X PUT -H "AccessKey: $BUNNY_BUCKET_PASSWORD" --data-binary "@$FILE" "$DEST"
+    echo ""; echo ""
+done

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -76,7 +76,7 @@ const createWindow = (): void => {
     // Auto updater
     if (process.env.NODE_ENV !== 'development') {
         // The Squirrel application will watch the provided URL
-        autoUpdater.setFeedURL({ url: 'https://flybywiresim-packages.nyc3.digitaloceanspaces.com/installer' });
+        autoUpdater.setFeedURL({ url: 'https://cdn.flybywiresim.com/installer/stable' });
 
         autoUpdater.addListener('update-downloaded', (event, releaseNotes, releaseName) => {
             mainWindow.webContents.send('update-downloaded', { event, releaseNotes, releaseName });


### PR DESCRIPTION
## Summary of Changes
Upload releases to the new CDN. Keep old CDN for a single release to keep backward compatibility.

## Screenshots (if necessary)
N/A

## Additional context
N/A

Discord username (if different from GitHub): nistei#1362
