### PR TITLE
refactor: use redux for track latest versions

### DIFF
--- a/src/renderer/components/AircraftSection/TrackSelector.tsx
+++ b/src/renderer/components/AircraftSection/TrackSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import styled from "styled-components";
 import { colors, noPadding, smallCard } from "renderer/style/theme";
 import { ModTrack } from "renderer/components/App";
@@ -17,28 +17,20 @@ export const Tracks = styled.div`
 type TrackProps = {
     className?: string,
     track: ModTrack,
+    latestVersionName: string,
     isSelected: boolean,
     isInstalled: boolean,
     // eslint-disable-next-line no-unused-vars
     onSelected(track: ModTrack): void,
 };
 
-const BaseTrack: React.FC<TrackProps> = (props) => {
-    const [latestVersionName, setLatestVersionName] = useState('');
-
-    useEffect(() => {
-        props.track.latestVersionName.then(name => {
-            typeof name === 'string' ? setLatestVersionName(name) : setLatestVersionName(name.title);
-        });
-    });
-
-    return (
-        <div className={props.className} onClick={() => props.onSelected(props.track)}>
-            <TrackTitle>{props.track.name}</TrackTitle>
+const BaseTrack: React.FC<TrackProps> = ({ className, track, latestVersionName, onSelected }) =>
+    (
+        <div className={className} onClick={() => onSelected(track)}>
+            <TrackTitle>{track.name}</TrackTitle>
             <TrackState><code>{latestVersionName}</code></TrackState>
         </div>
     );
-};
 
 /**
  * Visually displays of a mod track

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -29,7 +29,7 @@ import fs from "fs-extra";
 import net from "net";
 import { getModReleases, Mod, ModTrack, ModVariant, ModVersion } from "renderer/components/App";
 import { setupInstallPath } from 'renderer/actions/install-path.utils';
-import { DownloadItem, RootStore } from 'renderer/redux/types';
+import { DownloadItem, ModAndTrackLatestVersionNamesState, RootStore } from 'renderer/redux/types';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { deleteDownload, registerDownload, updateDownloadProgress } from 'renderer/redux/actions/downloads.actions';
 import { callWarningModal } from "renderer/redux/actions/warningModal.actions";
@@ -41,7 +41,6 @@ import * as path from 'path';
 import os from 'os';
 import store from '../../redux/store';
 import * as actionTypes from '../../redux/actionTypes';
-import { ModAndTrackLatestVersionNames } from "renderer/redux/reducers/latestVersionNames.reducer";
 
 const settings = new Store;
 
@@ -57,16 +56,10 @@ type ConnectedAircraftSectionProps = {
     selectedtrack: ModTrack,
     installedtrack: ModTrack,
     installstatus: InstallStatus,
+    latestVersionNames: ModAndTrackLatestVersionNamesState
 }
 
-// All props
-type AircraftSectionProps = {
-    mod: Mod,
-    selectedtrack: ModTrack,
-    installedtrack: ModTrack,
-    installstatus : InstallStatus
-    latestVersionNames: ModAndTrackLatestVersionNames
-}
+type AircraftSectionProps = TransferredProps & ConnectedAircraftSectionProps
 
 let abortController: AbortController;
 

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -41,6 +41,7 @@ import * as path from 'path';
 import os from 'os';
 import store from '../../redux/store';
 import * as actionTypes from '../../redux/actionTypes';
+import { ModAndTrackLatestVersionNames } from "renderer/redux/reducers/latestVersionNames.reducer";
 
 const settings = new Store;
 
@@ -55,7 +56,7 @@ type TransferredProps = {
 type ConnectedAircraftSectionProps = {
     selectedtrack: ModTrack,
     installedtrack: ModTrack,
-    installstatus : InstallStatus,
+    installstatus: InstallStatus,
 }
 
 // All props
@@ -63,7 +64,8 @@ type AircraftSectionProps = {
     mod: Mod,
     selectedtrack: ModTrack,
     installedtrack: ModTrack,
-    installstatus : InstallStatus,
+    installstatus : InstallStatus
+    latestVersionNames: ModAndTrackLatestVersionNames
 }
 
 let abortController: AbortController;
@@ -141,6 +143,10 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
     const installStatus = props.installstatus;
     const setInstallStatus = (new_state: InstallStatus) => {
         store.dispatch({ type: actionTypes.SET_INSTALL_STATUS, payload: new_state });
+    };
+
+    const latestVersionNameForTrack = (mod: Mod, track: ModTrack) => {
+        return props.latestVersionNames.find((info) => info.modKey === mod.key && info.trackKey === track.key)?.name;
     };
 
     const [msfsIsOpen, setMsfsIsOpen] = useState<MsfsStatus>(MsfsStatus.Checking);
@@ -453,6 +459,7 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
                                     <Track
                                         key={track.key}
                                         track={track}
+                                        latestVersionName={latestVersionNameForTrack(props.mod, track)}
                                         isSelected={selectedTrack === track}
                                         isInstalled={installedTrack === track}
                                         onSelected={() => handleTrackSelection(track)}
@@ -469,6 +476,7 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
                                     <Track
                                         key={track.key}
                                         track={track}
+                                        latestVersionName={latestVersionNameForTrack(props.mod, track)}
                                         isSelected={selectedTrack === track}
                                         isInstalled={installedTrack === track}
                                         onSelected={() => handleTrackSelection(track)}

--- a/src/renderer/components/App/index.tsx
+++ b/src/renderer/components/App/index.tsx
@@ -1,5 +1,5 @@
 import { hot } from 'react-hot-loader';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { shell } from "electron";
 import { Layout, Menu, } from 'antd';
 import SimpleBar from 'simplebar-react';
@@ -109,7 +109,7 @@ export const getModReleases = async (mod: Mod): Promise<ModVersion[]> => {
     return releases;
 };
 
-export const fetchLatestVersionNames = async (mod: Mod) => {
+export const fetchLatestVersionNames = async (mod: Mod): Promise<void> => {
     if (mod.variants.length > 0) {
         mod.variants[0].tracks.forEach(async (track) => {
             store.dispatch<SetModAndTrackLatestVersionName>({
@@ -231,7 +231,9 @@ function App() {
         }
     ];
 
-    mods.forEach(fetchLatestVersionNames);
+    useEffect(() => {
+        mods.forEach(fetchLatestVersionNames);
+    }, []);
 
     const [selectedItem, setSelectedItem] = useState<string>(mods[0].key);
 

--- a/src/renderer/redux/actionTypes/index.ts
+++ b/src/renderer/redux/actionTypes/index.ts
@@ -6,3 +6,4 @@ export const SET_INSTALL_STATUS = 'setInstallStatus';
 export const CALL_CHANGELOG = 'callChangelog';
 export const SET_SELECTED_TRACK = 'setSelectedTrack';
 export const SET_INSTALLED_TRACK = 'setInstalledTrack';
+export const SET_MOD_AND_TRACK_LATEST_VERSION_NAME = 'setModReleaseInfo';

--- a/src/renderer/redux/reducers/index.ts
+++ b/src/renderer/redux/reducers/index.ts
@@ -5,6 +5,7 @@ import warningModalReducer from 'renderer/redux/reducers/warningModal.reducer';
 import installStatusReducer from 'renderer/redux/reducers/installStatus.reducer';
 import selectedTrackReducer from 'renderer/redux/reducers/selectedTrack.reducer';
 import installedTrackReducer from 'renderer/redux/reducers/installedTrack.reducer';
+import latestVersionNamesReducer from 'renderer/redux/reducers/latestVersionNames.reducer';
 
 const rootReducer = combineReducers({
     downloads: downloadsReducer,
@@ -13,6 +14,7 @@ const rootReducer = combineReducers({
     installstatus: installStatusReducer,
     selectedtrack: selectedTrackReducer,
     installedtrack: installedTrackReducer,
+    latestVersionNames: latestVersionNamesReducer,
 });
 
 export default rootReducer;

--- a/src/renderer/redux/reducers/latestVersionNames.reducer.ts
+++ b/src/renderer/redux/reducers/latestVersionNames.reducer.ts
@@ -1,11 +1,9 @@
 import * as actionTypes from '../actionTypes';
-import { SetModAndTrackLatestVersionName } from '../types';
+import { ModAndTrackLatestVersionNamesState, SetModAndTrackLatestVersionName } from '../types';
 
-export type ModAndTrackLatestVersionNames = { modKey: string, trackKey: string, name: string }[]
+const initialState: ModAndTrackLatestVersionNamesState = [];
 
-const initialState: ModAndTrackLatestVersionNames = [];
-
-const reducer = (state = initialState, action: SetModAndTrackLatestVersionName): ModAndTrackLatestVersionNames => {
+const reducer = (state = initialState, action: SetModAndTrackLatestVersionName): ModAndTrackLatestVersionNamesState => {
     switch (action.type) {
         case actionTypes.SET_MOD_AND_TRACK_LATEST_VERSION_NAME:
             return [...state, action.payload];

--- a/src/renderer/redux/reducers/latestVersionNames.reducer.ts
+++ b/src/renderer/redux/reducers/latestVersionNames.reducer.ts
@@ -1,0 +1,17 @@
+import * as actionTypes from '../actionTypes';
+import { SetModAndTrackLatestVersionName } from '../types';
+
+export type ModAndTrackLatestVersionNames = { modKey: string, trackKey: string, name: string }[]
+
+const initialState: ModAndTrackLatestVersionNames = [];
+
+const reducer = (state = initialState, action: SetModAndTrackLatestVersionName): ModAndTrackLatestVersionNames => {
+    switch (action.type) {
+        case actionTypes.SET_MOD_AND_TRACK_LATEST_VERSION_NAME:
+            return [...state, action.payload];
+        default:
+            return state;
+    }
+};
+
+export default reducer;

--- a/src/renderer/redux/types.ts
+++ b/src/renderer/redux/types.ts
@@ -58,9 +58,19 @@ export interface SelectedTrackAction {
     type: typeof actions.SET_SELECTED_TRACK
     payload: ModTrack
 }
+
 export interface InstalledTrackAction {
     type: typeof actions.SET_INSTALLED_TRACK
     payload: ModTrack
+}
+
+export interface SetModAndTrackLatestVersionName {
+    type: typeof actions.SET_MOD_AND_TRACK_LATEST_VERSION_NAME
+    payload: {
+        modKey: string,
+        trackKey: string,
+        name: string
+    }
 }
 
 export interface ChangelogState {

--- a/src/renderer/redux/types.ts
+++ b/src/renderer/redux/types.ts
@@ -64,6 +64,8 @@ export interface InstalledTrackAction {
     payload: ModTrack
 }
 
+export type ModAndTrackLatestVersionNamesState = { modKey: string, trackKey: string, name: string }[]
+
 export interface SetModAndTrackLatestVersionName {
     type: typeof actions.SET_MOD_AND_TRACK_LATEST_VERSION_NAME
     payload: {


### PR DESCRIPTION
## Summary of Changes

* Use redux for storing state of latest mod track latest versions
* In a future PR: Use redux to store state of version history

Discord username (if different from GitHub): someperson#4953
