### PR TITLE
feat: support alternative package names

### DIFF
--- a/src/renderer/components/App/index.tsx
+++ b/src/renderer/components/App/index.tsx
@@ -41,6 +41,7 @@ export type Mod = {
     description: string,
     menuIconUrl: string,
     targetDirectory: string,
+    alternativeNames?: string[],
     variants: ModVariant[],
     enabled: boolean,
 }
@@ -144,7 +145,10 @@ function App() {
                 'aircraft family. The baseline A320neo jetliner has a choice of two new-generation engines ' +
                 '(the PurePower PW1100G-JM from Pratt and Whitney and the LEAP-1A from CFM International) ' +
                 'and features large, fuel-saving wingtip devices known as Sharklets.',
-            targetDirectory: 'A32NX',
+            targetDirectory: 'flybywire-aircraft-a320-neo',
+            alternativeNames: [
+                'A32NX',
+            ],
             variants: [
                 {
                     name: 'Neo (CFM LEAP-1A)',


### PR DESCRIPTION
## Summary of Changes
Install directory will be renamed from `A32NX`  to `flybywire-aircraft-a320-neo`. Both variants need to be supported.

## Screenshots (if necessary)
N/A

## Additional context
N/A

Discord username (if different from GitHub): nistei#1362

## Testing instructions
Do not use the experimental version since the CDN purge isn't done automatically for that version yet.

1. Have an existing install called `A32NX`
2. Update/Change Version
    - `A32NX` directory should get replaced by updated `flybywire-aircraft-a320-neo` directory
3. Update/Change Version
    - `flybywire-aircraft-a320-neo` should stay but get updated
4. Remove `flybywire-aircraft-a320-neo` directory
5. Install Dev or Stable
    - `flybywire-aircraft-a320-neo` is back
6. Test basic addon functionality in sim