### PR TITLE
fix: reduce cache timeout for release info

### DIFF
--- a/src/renderer/components/App/index.tsx
+++ b/src/renderer/components/App/index.tsx
@@ -125,7 +125,8 @@ export const fetchLatestVersionNames = async (mod: Mod): Promise<void> => {
     }
 };
 
-const RELEASE_CACHE_LIMIT = 3600 * 1000 * 24;
+// 5 mins
+const RELEASE_CACHE_LIMIT = 5 * 60 * 1000;
 
 function App() {
     const mods: Mod[] = [


### PR DESCRIPTION
## Summary of Changes
Reduce the cache timeout to 5 minutes.

## Screenshots (if necessary)
N/A

## Additional context
N/A

Discord username (if different from GitHub): nistei#1362
