### PR TITLE
fix: disable cancel button while decompressing

### DIFF
--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -418,7 +418,11 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
                 return (
                     <ButtonContainer>
                         <StateText>{download?.progress >= 99 ? 'Decompressing' : `Downloading ${download?.module.toLowerCase()} module: ${download?.progress}%`}</StateText>
-                        <CancelButton onClick={handleCancel}>Cancel</CancelButton>
+                        {
+                            download?.progress >= 99 ?
+                                <DisabledButton text='Cancel'/> :
+                                <CancelButton onClick={handleCancel}>Cancel</CancelButton>
+                        }
                     </ButtonContainer>
                 );
             case InstallStatus.DownloadDone:


### PR DESCRIPTION
## Summary of Changes
Disable the cancel button while decompressing to prevent a non-atomic filesystem action.

## Screenshots (if necessary)
![image](https://user-images.githubusercontent.com/1652722/111855678-8fd81e00-8926-11eb-8ff7-dbc0d827d2c0.png)


## Additional context
N/A

Discord username (if different from GitHub): nistei#1362
