### PR TITLE
feat: cache busting and exponential backoff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0",
       "dependencies": {
         "@ant-design/icons": "^4.4.0",
-        "@flybywiresim/fragmenter": "^0.1.9",
+        "@flybywiresim/fragmenter": "^0.2.1",
         "antd": "^4.12.2",
         "electron-squirrel-startup": "^1.0.0",
         "electron-store": "^6.0.1",
@@ -3920,9 +3920,9 @@
       "license": "MIT"
     },
     "node_modules/@flybywiresim/fragmenter": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@flybywiresim/fragmenter/-/fragmenter-0.1.9.tgz",
-      "integrity": "sha512-CZzKt974iWT4wxlBQEpDvPDPHNxfSYTAF9eZltarJx52WXczHNfoqqPejk/HkYKX8mOKVhZlGXYBfKWb2Yobyw=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@flybywiresim/fragmenter/-/fragmenter-0.2.1.tgz",
+      "integrity": "sha512-eeD+JR+p9QBaarlHwGEsZEjS1vnRIVtSmLzVbr/wi5CnI8kKYqz7bzYPTIAF17GNCU+WMgJuNicyAOsTyoXp6Q=="
     },
     "node_modules/@flybywiresim/tailwind-config": {
       "version": "0.3.0",
@@ -22416,9 +22416,9 @@
       "dev": true
     },
     "@flybywiresim/fragmenter": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@flybywiresim/fragmenter/-/fragmenter-0.1.9.tgz",
-      "integrity": "sha512-CZzKt974iWT4wxlBQEpDvPDPHNxfSYTAF9eZltarJx52WXczHNfoqqPejk/HkYKX8mOKVhZlGXYBfKWb2Yobyw=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@flybywiresim/fragmenter/-/fragmenter-0.2.1.tgz",
+      "integrity": "sha512-eeD+JR+p9QBaarlHwGEsZEjS1vnRIVtSmLzVbr/wi5CnI8kKYqz7bzYPTIAF17GNCU+WMgJuNicyAOsTyoXp6Q=="
     },
     "@flybywiresim/tailwind-config": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^4.4.0",
-    "@flybywiresim/fragmenter": "^0.1.9",
+    "@flybywiresim/fragmenter": "^0.2.1",
     "antd": "^4.12.2",
     "electron-squirrel-startup": "^1.0.0",
     "electron-store": "^6.0.1",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -152,6 +152,10 @@ function configureSettings(app: App) {
     if (!settings.has('mainSettings.disableExperimentalWarning')) {
         settings.set('mainSettings.disableExperimentalWarning', false);
     }
+    if (!settings.has('mainSettings.useCdnCache')) {
+        settings.set('mainSettings.useCdnCache', true);
+    }
+
     if (!settings.has('mainSettings.msfsPackagePath')) {
         let userPath = null;
 

--- a/src/renderer/components/GeneralSettings/index.tsx
+++ b/src/renderer/components/GeneralSettings/index.tsx
@@ -56,14 +56,36 @@ const DisableWarningSettingItem = (props: {disableWarning: boolean, setDisableWa
     );
 };
 
+const UseCdnSettingItem = (props: {useCdnCache: boolean, setUseCdnCache: CallableFunction}) => {
+    const handleClick = () => {
+        const newState = !props.useCdnCache;
+        props.setUseCdnCache(newState);
+        settings.set('mainSettings.useCdnCache', newState);
+    };
+
+    return (
+        <div className="flex items-center mb-2 mt-2">
+            <span className="text-base">Use CDN (Faster Downloads)</span>
+            <input
+                type="checkbox"
+                checked={props.useCdnCache}
+                onChange={handleClick}
+                className="ml-auto mr-2 w-5 h-5 rounded-sm checked:bg-blue-600 checked:border-transparent"
+            />
+        </div>
+    );
+};
+
 function index(): JSX.Element {
     const [installPath, setInstallPath] = useState<string>(settings.get('mainSettings.msfsPackagePath') as string);
     const [disableWarning, setDisableWarning] = useState<boolean>(settings.get('mainSettings.disableExperimentalWarning') as boolean);
+    const [useCdnCache, setUseCdnCache] = useState<boolean>(settings.get('mainSettings.useCdnCache') as boolean);
 
     const handleReset = async () => {
         settings.clear();
         setInstallPath(await configureInitialInstallPath());
         settings.set('mainSettings.disableExperimentalWarning', false);
+        settings.set('mainSettings.useCdnCache', true);
         setDisableWarning(false);
     };
 
@@ -74,6 +96,7 @@ function index(): JSX.Element {
                 <SettingsItems>
                     <InstallPathSettingItem path={installPath} setPath={setInstallPath} />
                     <DisableWarningSettingItem disableWarning={disableWarning} setDisableWarning={setDisableWarning} />
+                    <UseCdnSettingItem useCdnCache={useCdnCache} setUseCdnCache={setUseCdnCache} />
                 </SettingsItems>
             </Container>
             <InfoContainer>

--- a/src/renderer/redux/actions/downloads.actions.ts
+++ b/src/renderer/redux/actions/downloads.actions.ts
@@ -11,13 +11,15 @@ export function registerDownload(id: string, module: string): RegisterNewDownloa
     };
 }
 
-export function updateDownloadProgress(id: string, module: string, progress: number): UpdateDownloadProgressAction {
+export function updateDownloadProgress(id: string, module: string, progress: number, retryCount: number, retryWait: number): UpdateDownloadProgressAction {
     return {
         type: actionTypes.UPDATE_DOWNLOAD_PROGRESS,
         payload: {
             id,
             progress,
-            module
+            module,
+            retryCount,
+            retryWait
         }
     };
 }

--- a/src/renderer/redux/reducers/downloads.reducer.ts
+++ b/src/renderer/redux/reducers/downloads.reducer.ts
@@ -20,6 +20,8 @@ const reducer = produce((downloads: Draft<DownloadsState>, action: DownloadActio
                 id: action.payload.id,
                 progress: 0,
                 module: action.payload.module,
+                retryCount: 0,
+                retryWait: 0,
             });
             break;
         case actionTypes.DELETE_DOWNLOAD:

--- a/src/renderer/redux/types.ts
+++ b/src/renderer/redux/types.ts
@@ -5,7 +5,9 @@ import { InstallStatus } from 'renderer/components/AircraftSection';
 export interface DownloadItem {
     id: string
     progress: number
-    module: string
+    module: string,
+    retryCount: number,
+    retryWait: number,
 }
 
 export type DownloadsState = DownloadItem[];
@@ -16,6 +18,8 @@ export interface UpdateDownloadProgressAction {
         id: string
         progress: number
         module: string
+        retryCount: number,
+        retryWait: number,
     }
 }
 


### PR DESCRIPTION
## Summary of Changes
- Allow users to disable the CDN by cache-busting.
- Fragmenter retries after an invalid CRC and automatically uses cache-busting after the first failure.

## Screenshots (if necessary)
![image](https://user-images.githubusercontent.com/1652722/112075231-66163580-8b78-11eb-8124-648cc1dc066f.png)
![image](https://user-images.githubusercontent.com/1652722/112075981-d07ba580-8b79-11eb-8663-dfb780b610d0.png)


## Additional context

Discord username (if different from GitHub): nistei#1362
