### PR TITLE
fix: use community directory for caching when it is encrypted

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,10 @@
 <!-- Use the following format below -->
 <!--  1. [Changed Area] Title of changes - @github username (Name)  -->
 
+## 1.2.0
+
+1. [LOGIC] Fix downloads failing in encrypted directories - @nistei (nistei#1362)
+
 ## 1.1.1
 
 1. [LOGIC] Fix full downloads broken for some users - @nistei (nistei#1362)

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -36,7 +36,6 @@ import { Version, Versions } from "renderer/components/AircraftSection/VersionHi
 import { Track, Tracks } from "renderer/components/AircraftSection/TrackSelector";
 import { install, needsUpdate, getCurrentInstall } from "@flybywiresim/fragmenter";
 import * as path from 'path';
-import os from 'os';
 import store from '../../redux/store';
 import * as actionTypes from '../../redux/actionTypes';
 
@@ -87,7 +86,7 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
     };
 
     const getTempDir = (): string => {
-        return path.join(os.tmpdir(), 'flybywire_installer');
+        return path.join(settings.get('mainSettings.msfsPackagePath') as string, `flybywire_current_install_${(Math.random() * 1000).toFixed(0)}`);
     };
 
     const findInstalledTrack = (): ModTrack => {


### PR DESCRIPTION
Fixes #179

## Summary of Changes
Test, whether the install target is encrypted. If it is we have to use it as a temporary directory otherwise the copy back from the temp dir will fail.

## Screenshots (if necessary)
N/A

## Additional context
We've had issues with temporary directories being left behind. This was caused by a race-condition in fragmenter which has been fixed.

Discord username (if different from GitHub): nistei#1362
