### PR TITLE
feat: introduce error screen

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -29,7 +29,7 @@ const createWindow = (): void => {
         minHeight: 700,
         frame: false,
         icon: 'src/main/icons/icon.ico',
-        backgroundColor: '#1C1C1C',
+        backgroundColor: '#1b2434',
         show: false,
         webPreferences: {
             nodeIntegration: true,

--- a/src/renderer/renderer.tsx
+++ b/src/renderer/renderer.tsx
@@ -51,6 +51,16 @@ InstallerConfiguration.obtain().then((config: Configuration) => {
         </Provider>,
         document.getElementById('root')
     );
+}).catch((error: Error) => {
+    ReactDOM.render(
+        <div className="h-screen flex flex-col gap-y-5 justify-center items-center bg-navy text-gray-100">
+            <span className="text-5xl font-semibold">Something went very wrong.</span>
+            <span className="w-3/5 text-center text-2xl">We could not configure your installer. Please seek support on the Discord #help channel or on GitHub and provide a screenshot of the following information:</span>
+            <pre className="w-3/5 bg-gray-700 text-2xl font-mono px-6 py-2.5 mb-0 rounded-lg">{error.stack}</pre>
+            <button className="bg-navy-lightest hover:bg-navy-lighter px-5 py-2 text-lg font-semibold rounded-lg" onClick={() => remote.app.quit()}>Close the Installer</button>
+        </div>,
+        document.getElementById('root')
+    );
 });
 
 // When document has loaded, initialize
@@ -65,11 +75,11 @@ window.onbeforeunload = () => {
 };
 
 function handleWindowControls() {
-    document.getElementById('min-button').addEventListener("click", () => {
+    document.getElementById('min-button')?.addEventListener("click", () => {
         win.minimize();
     });
 
-    document.getElementById('max-button').addEventListener("click", () => {
+    document.getElementById('max-button')?.addEventListener("click", () => {
         if (win.isMaximized()) {
             win.unmaximize();
         } else {
@@ -77,7 +87,7 @@ function handleWindowControls() {
         }
     });
 
-    document.getElementById('close-button').addEventListener("click", () => {
+    document.getElementById('close-button')?.addEventListener("click", () => {
         settings.set('cache.main.maximized', win.isMaximized());
         const winSize = win.getSize();
 


### PR DESCRIPTION
Fixes #196

## Summary of Changes

* Introduce error screen which displays a stack trace and error message when a configuration could not be loaded

## Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/4503241/112739839-b0ffc680-8f45-11eb-9f4a-8cac6b0abfec.png)

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): someperson#4953
