### PR TITLE
feat: fragmenter hashes in query params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0",
       "dependencies": {
         "@ant-design/icons": "^4.4.0",
-        "@flybywiresim/fragmenter": "^0.3.0",
+        "@flybywiresim/fragmenter": "^0.4.0",
         "antd": "^4.12.2",
         "electron-squirrel-startup": "^1.0.0",
         "electron-store": "^6.0.1",
@@ -3921,9 +3921,9 @@
       "license": "MIT"
     },
     "node_modules/@flybywiresim/fragmenter": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@flybywiresim/fragmenter/-/fragmenter-0.3.0.tgz",
-      "integrity": "sha512-qaMX14yjVMwYZpSu4PJRqY0bebSuXVf8Mc/2i/AqLA1vNl8EzOufpXToQHaZO3cNCG1gUJq8rSztM9Q6gbQxRg=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@flybywiresim/fragmenter/-/fragmenter-0.4.0.tgz",
+      "integrity": "sha512-J8sRzoMTem6Mg3I0LjzRchQPgrJolDufqUCpOIfAqMtqC7L8DP8gnu0Y1jdZpAyHmjFy2TeLB79wXdOVW6dqLg=="
     },
     "node_modules/@flybywiresim/tailwind-config": {
       "version": "0.3.0",
@@ -22425,9 +22425,9 @@
       "dev": true
     },
     "@flybywiresim/fragmenter": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@flybywiresim/fragmenter/-/fragmenter-0.3.0.tgz",
-      "integrity": "sha512-qaMX14yjVMwYZpSu4PJRqY0bebSuXVf8Mc/2i/AqLA1vNl8EzOufpXToQHaZO3cNCG1gUJq8rSztM9Q6gbQxRg=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@flybywiresim/fragmenter/-/fragmenter-0.4.0.tgz",
+      "integrity": "sha512-J8sRzoMTem6Mg3I0LjzRchQPgrJolDufqUCpOIfAqMtqC7L8DP8gnu0Y1jdZpAyHmjFy2TeLB79wXdOVW6dqLg=="
     },
     "@flybywiresim/tailwind-config": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^4.4.0",
-    "@flybywiresim/fragmenter": "^0.3.0",
+    "@flybywiresim/fragmenter": "^0.4.0",
     "antd": "^4.12.2",
     "electron-squirrel-startup": "^1.0.0",
     "electron-store": "^6.0.1",

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -202,7 +202,7 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
 
         try {
             const updateInfo = await needsUpdate(selectedTrack.url, installDir, {
-                forceCacheBust: !(settings.get('mainSettings.useCdnCache') as boolean)
+                forceCacheBust: true
             });
             console.log('Update info', updateInfo);
 
@@ -303,7 +303,8 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
             console.log('Starting fragmenter download for URL', track.url);
             const installResult = await installer.install(signal, {
                 forceCacheBust: !(settings.get('mainSettings.useCdnCache') as boolean),
-                forceFreshInstall: false
+                forceFreshInstall: false,
+                forceManifestCacheBust: true,
             });
             console.log('Fragmenter download finished for URL', track.url);
 


### PR DESCRIPTION
## Summary of Changes
Send the module- and full-hash of the target version as query params in fragmenter. To always get the newest module-info a permanent cache-busting is enabled for the manifest request, which is only 2kB in size. This will act as an automatic cache-busting in case the automatic purge didn't work on bunny.net. The module cache-rate will not be affected since the hashes are the same for everyone and this is only a fallback to the existing purging.

## Screenshots (if necessary)
![image](https://user-images.githubusercontent.com/1652722/112876810-3f02bb00-90c6-11eb-9b13-df9faf269a81.png)


## Additional context
N/A

Discord username (if different from GitHub): nistei#1362
