### PR TITLE
refactor: improve last release info, introduce AddonData

### DIFF
--- a/src/renderer/components/AircraftSection/TrackSelector.tsx
+++ b/src/renderer/components/AircraftSection/TrackSelector.tsx
@@ -25,7 +25,7 @@ export const Track: React.FC<TrackProps> = ({ isSelected, isInstalled, handleSel
     const latestVersionName = useSelector<InstallerStore, string>(state => {
         return state.latestVersionNames
             .find((entry) => entry.modKey === mod.key && entry.trackKey === track.key)
-            ?.name ?? '<unknown>';
+            ?.info.name ?? '<unknown>';
     });
 
     const makeBorderStyle = () => {

--- a/src/renderer/components/App/index.tsx
+++ b/src/renderer/components/App/index.tsx
@@ -14,12 +14,13 @@ import { GitVersions } from "@flybywiresim/api-client";
 import { DataCache } from '../../utils/DataCache';
 import * as actionTypes from '../../redux/actionTypes';
 import store from '../../redux/store';
-import { SetModAndTrackLatestVersionName } from "renderer/redux/types";
+import { SetModAndTrackLatestReleaseInfo } from "renderer/redux/types";
 import { Settings } from "tabler-icons-react";
 import { SidebarItem, SidebarMod, SidebarPublisher } from "renderer/components/App/SideBar";
 import InstallerUpdate from "renderer/components/InstallerUpdate";
 import { WindowButtons } from "renderer/components/WindowActionButtons";
 import { Configuration, Mod, ModVersion } from "renderer/utils/InstallerConfiguration";
+import { AddonData } from "renderer/utils/AddonData";
 
 const releaseCache = new DataCache<ModVersion[]>('releases', 1000 * 3600 * 24);
 
@@ -58,12 +59,14 @@ export const getModReleases = async (mod: Mod): Promise<ModVersion[]> => {
 
 export const fetchLatestVersionNames = async (mod: Mod): Promise<void> => {
     mod.tracks.forEach(async (track) => {
-        store.dispatch<SetModAndTrackLatestVersionName>({
-            type: actionTypes.SET_MOD_AND_TRACK_LATEST_VERSION_NAME,
+        const trackLatestVersionName = await AddonData.latestVersionForTrack(mod, track);
+
+        store.dispatch<SetModAndTrackLatestReleaseInfo>({
+            type: actionTypes.SET_MOD_AND_TRACK_LATEST_RELEASE_INFO,
             payload: {
                 modKey: mod.key,
                 trackKey: track.key,
-                name: await track.fetchLatestVersionName()
+                info: trackLatestVersionName,
             }
         });
     });

--- a/src/renderer/data.tsx
+++ b/src/renderer/data.tsx
@@ -1,13 +1,9 @@
 import React from "react";
 import { shell } from "electron";
-import { DataCache } from "renderer/utils/DataCache";
-import { GitVersions } from "@flybywiresim/api-client";
 import { Configuration } from "./utils/InstallerConfiguration";
 
 import A320NoseSVG from "renderer/assets/a32nx_nose.svg";
 import A380NoseSVG from "renderer/assets/a380x_nose.svg";
-
-const RELEASE_CACHE_LIMIT = 5 * 60 * 1000;
 
 export const defaultConfiguration: Configuration = {
     mods: [
@@ -47,9 +43,8 @@ export const defaultConfiguration: Configuration = {
                             </p>
                         </>,
                     isExperimental: false,
-                    fetchLatestVersionName() {
-                        return DataCache.from<string>('latest_version_stable', RELEASE_CACHE_LIMIT)
-                            .fetchOrCompute(async () => (await GitVersions.getReleases('flybywiresim', 'a32nx'))[0].name);
+                    releaseModel: {
+                        type: 'githubRelease',
                     },
                 },
                 {
@@ -66,10 +61,10 @@ export const defaultConfiguration: Configuration = {
                             </p>
                         </>,
                     isExperimental: false,
-                    fetchLatestVersionName() {
-                        return DataCache.from<string>('latest_version_dev', RELEASE_CACHE_LIMIT)
-                            .fetchOrCompute(async () => (await GitVersions.getNewestCommit('flybywiresim', 'a32nx', 'master')).sha.substring(0, 7));
-                    }
+                    releaseModel: {
+                        type: 'githubBranch',
+                        branch: 'master',
+                    },
                 },
                 {
                     name: 'Experimental',
@@ -90,9 +85,9 @@ export const defaultConfiguration: Configuration = {
 
                             <p style={{ marginTop: '1em', fontWeight: 'bold' }}>Please be aware that no support will be offered via Discord help channels.</p>
                         </>,
-                    fetchLatestVersionName() {
-                        return DataCache.from<string>('latest_version_experimental', RELEASE_CACHE_LIMIT)
-                            .fetchOrCompute(async () => (await GitVersions.getNewestCommit('flybywiresim', 'a32nx', 'autopilot')).sha.substring(0, 7));
+                    releaseModel: {
+                        type: 'githubBranch',
+                        branch: 'autopilot',
                     },
                 },
             ],

--- a/src/renderer/redux/actionTypes/index.ts
+++ b/src/renderer/redux/actionTypes/index.ts
@@ -6,4 +6,4 @@ export const SET_INSTALL_STATUS = 'setInstallStatus';
 export const CALL_CHANGELOG = 'callChangelog';
 export const SET_SELECTED_TRACK = 'setSelectedTrack';
 export const SET_INSTALLED_TRACK = 'setInstalledTrack';
-export const SET_MOD_AND_TRACK_LATEST_VERSION_NAME = 'setModReleaseInfo';
+export const SET_MOD_AND_TRACK_LATEST_RELEASE_INFO = 'setModReleaseInfo';

--- a/src/renderer/redux/reducers/latestVersionNames.reducer.ts
+++ b/src/renderer/redux/reducers/latestVersionNames.reducer.ts
@@ -1,11 +1,11 @@
 import * as actionTypes from '../actionTypes';
-import { ModAndTrackLatestVersionNamesState, SetModAndTrackLatestVersionName } from '../types';
+import { ModAndTrackLatestVersionNamesState, SetModAndTrackLatestReleaseInfo } from '../types';
 
 const initialState: ModAndTrackLatestVersionNamesState = [];
 
-const reducer = (state = initialState, action: SetModAndTrackLatestVersionName): ModAndTrackLatestVersionNamesState => {
+const reducer = (state = initialState, action: SetModAndTrackLatestReleaseInfo): ModAndTrackLatestVersionNamesState => {
     switch (action.type) {
-        case actionTypes.SET_MOD_AND_TRACK_LATEST_VERSION_NAME:
+        case actionTypes.SET_MOD_AND_TRACK_LATEST_RELEASE_INFO:
             return [...state, action.payload];
         default:
             return state;

--- a/src/renderer/redux/types.ts
+++ b/src/renderer/redux/types.ts
@@ -1,6 +1,7 @@
 import * as actions from './actionTypes';
 import { InstallStatus } from 'renderer/components/AircraftSection';
 import { ModTrack } from "renderer/utils/InstallerConfiguration";
+import { ReleaseInfo } from "renderer/utils/AddonData";
 
 export interface DownloadItem {
     id: string
@@ -64,14 +65,14 @@ export interface InstalledTrackAction {
     payload: ModTrack
 }
 
-export type ModAndTrackLatestVersionNamesState = { modKey: string, trackKey: string, name: string }[]
+export type ModAndTrackLatestVersionNamesState = { modKey: string, trackKey: string, info: ReleaseInfo }[]
 
-export interface SetModAndTrackLatestVersionName {
-    type: typeof actions.SET_MOD_AND_TRACK_LATEST_VERSION_NAME
+export interface SetModAndTrackLatestReleaseInfo {
+    type: typeof actions.SET_MOD_AND_TRACK_LATEST_RELEASE_INFO
     payload: {
         modKey: string,
         trackKey: string,
-        name: string
+        info: ReleaseInfo,
     }
 }
 

--- a/src/renderer/utils/AddonData.ts
+++ b/src/renderer/utils/AddonData.ts
@@ -1,0 +1,37 @@
+import { Mod, ModTrack, GithubBranchReleaseModel } from "renderer/utils/InstallerConfiguration";
+import { GitVersions } from "@flybywiresim/api-client";
+
+export type ReleaseInfo = {
+    name: string,
+    releaseDate: Date,
+    changelogUrl?: string,
+}
+
+export class AddonData {
+
+    static async latestVersionForTrack(mod: Mod, track: ModTrack): Promise<ReleaseInfo> {
+        if (track.releaseModel.type === 'githubRelease') {
+            return this.latestVersionForReleasedTrack(mod);
+        } else if (track.releaseModel.type === 'githubBranch') {
+            return this.latestVersionForRollingTrack(mod, track.releaseModel);
+        }
+    }
+
+    private static async latestVersionForReleasedTrack(mod: Mod): Promise<ReleaseInfo> {
+        return GitVersions.getReleases('flybywiresim', mod.repoName)
+            .then((releases) => ({
+                name: releases[0].name,
+                releaseDate: releases[0].publishedAt,
+                changelogUrl: releases[0].htmlUrl,
+            }));
+    }
+
+    private static async latestVersionForRollingTrack(mod: Mod, releaseModel: GithubBranchReleaseModel): Promise<ReleaseInfo> {
+        return GitVersions.getNewestCommit('flybywiresim', mod.repoName, releaseModel.branch)
+            .then((commit) => ({
+                name: commit.sha.substring(0, 7),
+                releaseDate: commit.timestamp,
+            }));
+    }
+
+}

--- a/src/renderer/utils/InstallerConfiguration.ts
+++ b/src/renderer/utils/InstallerConfiguration.ts
@@ -6,12 +6,23 @@ export type ModVersion = {
     type: 'major' | 'minor' | 'patch'
 }
 
+export type GithubReleaseReleaseModel = {
+    type: 'githubRelease',
+}
+
+export type GithubBranchReleaseModel = {
+    type: 'githubBranch',
+    branch: string,
+}
+
+export type ReleaseModel = GithubReleaseReleaseModel | GithubBranchReleaseModel
+
 type BaseModTrack = {
     name: string,
     key: string,
     url: string,
     description: JSX.Element,
-    fetchLatestVersionName: () => Promise<string>
+    releaseModel: ReleaseModel,
 }
 
 export type MainlineModTrack = BaseModTrack & { isExperimental: false }

--- a/src/renderer/utils/Msfs.ts
+++ b/src/renderer/utils/Msfs.ts
@@ -16,4 +16,5 @@ export class Msfs {
             });
         });
     }
+
 }


### PR DESCRIPTION
## Summary of Changes

* Change `Configuration` data model to include information on track release model (released or rolling)
* Introduce `ModData` utility for getting additional mod data, including latest releases
* Refactor Redux latest version state to include release date and changelog URL (not yet used)

Discord username (if different from GitHub): someperson#4953
