### PR TITLE
build: remove old cdn

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,16 +53,3 @@ jobs:
           BUNNY_BUCKET_PASSWORD: ${{ secrets.BUNNY_BUCKET_PASSWORD }}
           BUNNY_SECRET_TOKEN: ${{ secrets.BUNNY_SECRET_TOKEN }}
         run: ./scripts/cdn.sh out/make/squirrel.windows/x64 installer/stable
-
-      - name: Upload to DigitalOcean CDN
-        run: |
-          mkdir -p ~/.aws
-          touch ~/.aws/credentials
-
-          echo "[default]
-          aws_access_key_id = ${{ secrets.CDN_SPACE_ACCESS_KEY_ID }}
-          aws_secret_access_key = ${{ secrets.CDN_SPACE_SECRET_ACCESS_KEY }}" > ~/.aws/credentials
-
-          aws s3 sync ${{ env.ASSET_DIRECTORY }} s3://${{ secrets.CDN_SPACE_NAME }}/installer \
-                      --follow-symlinks \
-                      --endpoint https://${{ secrets.CDN_SPACE_REGION }}.digitaloceanspaces.com --acl public-read


### PR DESCRIPTION
Fixes #162

## Summary of Changes
Remove DigitalOcean CDN as we do not support it any longer.

Discord username (if different from GitHub): nistei#1362
