### PR TITLE
fix: disabled livery conversion ignored, changelog shown after reset

### DIFF
--- a/src/renderer/components/GeneralSettings/index.tsx
+++ b/src/renderer/components/GeneralSettings/index.tsx
@@ -27,7 +27,7 @@ const InstallPathSettingItem = (props: { path: string, setPath: (path: string) =
 
         if (path) {
             props.setPath(path);
-            if (!settings.get('mainSettings.separateLiveriesPath')) {
+            if (!settings.get('mainSettings.separateLiveriesPath') && !settings.get('mainSettings.disabledIncompatibleLiveriesWarning')) {
                 reloadLiveries();
             }
         }
@@ -47,7 +47,9 @@ const LiveriesPathSettingItem = (props: { path: string, setPath: (path: string) 
 
         if (path) {
             props.setPath(path);
-            reloadLiveries();
+            if (!settings.get('mainSettings.disabledIncompatibleLiveriesWarning')) {
+                reloadLiveries();
+            }
         }
     }
 
@@ -65,7 +67,9 @@ const SeparateLiveriesPathSettingItem = (props: {separateLiveriesPath: boolean, 
         const newState = !props.separateLiveriesPath;
         props.setSeperateLiveriesPath(newState);
         settings.set('mainSettings.separateLiveriesPath', newState);
-        reloadLiveries();
+        if (!settings.get('mainSettings.disabledIncompatibleLiveriesWarning')) {
+            reloadLiveries();
+        }
     };
 
     return (
@@ -169,6 +173,7 @@ function index(): JSX.Element {
 
     const handleReset = async () => {
         settings.clear();
+        settings.set('metaInfo.lastVersion', packageInfo.version);
         setInstallPath(await configureInitialInstallPath());
         setLiveriesPath(installPath);
         setSeparateLiveriesPath(false);


### PR DESCRIPTION
<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
<!--Fixes #[issue_no] -->

## Summary of Changes
- disabled livery conversion ignored in some cases
- changelog shown next restart after reset

<!--## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
Foxtrot Sierra#6420
