### PR TITLE
refactor: change a32nx background image

### DIFF
--- a/src/renderer/components/AircraftSection/styles.tsx
+++ b/src/renderer/components/AircraftSection/styles.tsx
@@ -3,7 +3,7 @@ import { Select, Progress } from 'antd';
 import styled from 'styled-components';
 import { DownloadOutlined } from '@ant-design/icons';
 import { colors, dropShadow, fontSizes } from "renderer/style/theme";
-import headerBackground from "renderer/assets/a32nx-background.png";
+import headerBackground from "renderer/assets/background-image/@bouveng.png";
 
 export const Container = styled.div<{ wait: number }>`
     visibility: ${props => props.wait ? 'hidden' : 'visible'};


### PR DESCRIPTION
Fixes #[issue_no]

## Summary of Changes
Changed current A32NX background to a new image from @bouveng
Also added folder for background image(s) for organization purposes 

## Screenshots (if necessary)
Before: 
![image](https://user-images.githubusercontent.com/62395728/137426885-b4182d8c-e7f8-4e84-9eb1-2277d2bb8be2.png)

After: 
![image](https://user-images.githubusercontent.com/62395728/137426906-c6a19248-caf2-4e62-a67b-6cb25dd34340.png)


## Additional context



Discord username (if different from GitHub): GhostEagle68#0030
