### PR TITLE
refactor: first iteration of new container UI

### DIFF
--- a/src/renderer/components/AircraftSection/VersionHistory.tsx
+++ b/src/renderer/components/AircraftSection/VersionHistory.tsx
@@ -13,6 +13,7 @@ const settings = new Store;
 export const Versions = styled.div`
   display: flex;
   flex-direction: column;
+  grid-row-gap: 7px;
 `;
 
 const GITHUB_RELEASE_BASE_URL = 'https://github.com/flybywiresim/a32nx/releases/tag/';
@@ -58,6 +59,10 @@ export const Version = styled(VersionBase)`
   display: grid;
   grid-template-columns: [start] 1fr [middle] 6fr [end] 3fr;
   grid-template-rows: [start] 30px [middle] auto;
+  background-color: #222c3d;
+  border-radius: 0.375rem;
+  --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 
   letter-spacing: .04em !important;
   

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -19,7 +19,14 @@ import {
     SwitchButton,
     TopContainer,
     UpdateButton,
-    VersionHistoryContainer
+    VersionHistoryContainer,
+    AboutContainer,
+    AddonDescriptionContainer,
+    A320neoDetailsContainer,
+    A320neoDetailsTitleContainer,
+    ReleaseHistoryContainer,
+    ExperimentalVersionsContainer,
+    MainlineVersionsContainer
 } from './styles';
 import Store from 'electron-store';
 import fs from "fs-extra";
@@ -496,7 +503,9 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
                 }
                 <TopContainer className={liveries.length > 0 ? 'mt-0' : '-mt-5'}>
                     <div>
-                        <h5 className="text-base text-teal-50 uppercase">Mainline versions</h5>
+                        <MainlineVersionsContainer>
+                            <h5 className="text-base text-teal-50 uppercase">Mainline versions</h5>
+                        </MainlineVersionsContainer>
                         <Tracks>
                             {
                                 props.addon.tracks.filter((track) => !track.isExperimental).map(track =>
@@ -513,7 +522,9 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
                         </Tracks>
                     </div>
                     <div>
-                        <h5 className="text-base text-teal-50 uppercase">Experimental versions</h5>
+                        <ExperimentalVersionsContainer>
+                            <h5 className="text-base text-teal-50 uppercase">Experimental versions</h5>
+                        </ExperimentalVersionsContainer>
                         <Tracks>
                             {
                                 props.addon.tracks.filter((track) => track.isExperimental).map(track =>
@@ -532,19 +543,30 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
                 </TopContainer>
                 <LeftContainer>
                     <DetailsContainer>
-                        <h3 className="font-semibold text-teal-50">About This Version</h3>
-                        <ReactMarkdown
-                            className="text-lg text-gray-300"
-                            children={selectedTrack?.description ?? ''}
-                            remarkPlugins={[remarkGfm]}
-                            linkTarget={"_blank"}
-                        />
-                        <h3 className="font-semibold text-teal-50">Details</h3>
-                        <p className="text-lg text-gray-300">{props.addon.description}</p>
+                        <AboutContainer>
+                            <h3 className="font-semibold text-teal-50">About This Version</h3>
+                        </AboutContainer>
+                        <AddonDescriptionContainer>
+                            <ReactMarkdown
+                                className="text-lg text-gray-300"
+                                children={selectedTrack?.description ?? ''}
+                                remarkPlugins={[remarkGfm]}
+                                linkTarget={"_blank"}
+                            />
+                        </AddonDescriptionContainer>
+                        <A320neoDetailsTitleContainer>
+                            <h3 className="font-semibold text-teal-50">Details</h3>
+                        </A320neoDetailsTitleContainer>
+
+                        <A320neoDetailsContainer>
+                            <p className="text-lg text-gray-300">{props.addon.description}</p>
+                        </A320neoDetailsContainer>
                     </DetailsContainer>
                 </LeftContainer>
                 <VersionHistoryContainer>
-                    <h3 className="font-semibold text-teal-50">Release History</h3>
+                    <ReleaseHistoryContainer>
+                        <h3 className="font-semibold text-teal-50">Release History</h3>
+                    </ReleaseHistoryContainer>
                     <Versions>
                         {
                             releases.map((version, idx) =>

--- a/src/renderer/components/AircraftSection/styles.tsx
+++ b/src/renderer/components/AircraftSection/styles.tsx
@@ -248,3 +248,57 @@ export const DisabledButton = styled(
             }}
             {...props}
         >{props.text}</InstallButtonTemplate>)``;
+
+export const AboutContainer = styled.div`
+    background-color: #222c3d;
+    border-radius: 0.375rem;
+    width: 20%;
+    --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+`;
+
+export const AddonDescriptionContainer = styled.div`
+    background-color: #222c3d;
+    border-radius: 0.375rem;
+    --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+`;
+
+export const A320neoDetailsTitleContainer = styled.div`
+    background-color: #222c3d;
+    border-radius: 0.375rem;
+    width: 8%;
+    --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+`;
+
+export const A320neoDetailsContainer = styled.div`
+    background-color: #222c3d;
+    border-radius: 0.375rem;
+    --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+`;
+
+export const ReleaseHistoryContainer = styled.div`
+    background-color: #222c3d;
+    border-radius: 0.375rem;
+    width: 60%;
+    --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+`;
+
+export const MainlineVersionsContainer = styled.div`
+    background-color: #222c3d;
+    border-radius: 0.375rem;
+    width: 35%;
+    --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+`;
+
+export const ExperimentalVersionsContainer = styled.div`
+    background-color: #222c3d;
+    border-radius: 0.375rem;
+    width: 90%;
+    --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+`;


### PR DESCRIPTION
Fixes #[issue_no]

## Summary of Changes
Added new UI to containers for addon description, A320neo details, mainline and experimental version titles (above addon tracks) and the release history. 

## Screenshots (if necessary)
Before:
![image](https://user-images.githubusercontent.com/62395728/137660687-91db248c-4789-49e1-9794-7cbde4f87158.png)

After:
![image](https://user-images.githubusercontent.com/62395728/137660705-eeca328a-162e-4489-bc53-4d1468470155.png)


## Additional context
As this is the first iteration of this new UI concept, please be detailed in your feedback! Do note text padding will be addressed soon! 

Discord username (if different from GitHub): GhostEagle68#0030
