### PR TITLE
refactor: changed some UI on release history

### DIFF
--- a/src/renderer/components/AircraftSection/VersionHistory.tsx
+++ b/src/renderer/components/AircraftSection/VersionHistory.tsx
@@ -74,6 +74,7 @@ export const Version = styled(VersionBase)`
     background-color: #222c3d;
     --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
     box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+    --timeline-node-color: ${props => props.index === 0 ? 'white' : '#00c2cc'};
   }
 
   & > * {

--- a/src/renderer/components/AircraftSection/VersionHistory.tsx
+++ b/src/renderer/components/AircraftSection/VersionHistory.tsx
@@ -58,17 +58,22 @@ export const Version = styled(VersionBase)`
   display: grid;
   grid-template-columns: [start] 1fr [middle] 6fr [end] 3fr;
   grid-template-rows: [start] 30px [middle] auto;
+  border-radius: 0.375rem;
+  width: auto;
 
   letter-spacing: .04em !important;
   
   --timeline-node-color: ${props => props.index === 0 ? 'white' : '#757575'};
   
-  --title-color: ${props => props.index === 0 ? 'white' : '#929292'};
-  --text-color: ${props => props.index === 0 ? 'white' : '#929292'};
+  --title-color: ${props => props.index === 0 ? 'white' : '#666666'};
+  --text-color: ${props => props.index === 0 ? 'white' : '#666666'};
   &:hover {
-    --title-color: #b3b3b3;
-    --text-color: #b3b3b3;
+    --title-color: #c2cbcc;
+    --text-color: #c2cbcc;
     cursor: pointer;
+    background-color: #222c3d;
+    --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
   }
 
   & > * {
@@ -80,7 +85,7 @@ const VersionLine = styled.svg`
   grid-column: start / middle;
   stroke: #757575;
   fill: #757575;
-  stroke-width: 1;
+  stroke-width: 1.5;
   
   circle {
     stroke: var(--timeline-node-color);


### PR DESCRIPTION
Fixes #[issue_no]

## Summary of Changes
Added a hover effect when you hover over each release on the release history timeline
-background-color
-shadow
-new text colors
-linewidth increased to 1.5

## Screenshots (if necessary)
Before:
![image](https://user-images.githubusercontent.com/62395728/138570751-6d344d93-06c7-4f4d-b3d6-b93253c0ed03.png)

After:
![image](https://user-images.githubusercontent.com/62395728/139735235-87d6fc3b-7491-4f7d-ac62-e94b5f60528e.png)

## Additional context

Discord username (if different from GitHub): GhostEagle#0030
