### PR TITLE
feat: Start msfs from the installer

### DIFF
--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -474,11 +474,11 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
 
     const handleStartMsfs = () => {
         const child = require('child_process').execFile;
-        const file = "FlightSimulator.exe";
+        const FILE_NAME = "FlightSimulator.exe";
         const MSFSisRunningButton = document.getElementById('msfsrunning');
         MSFSisRunningButton.removeAttribute("hidden");
         document.getElementById("handleStartMsfs").style.display = "none";
-        child(file, () => {});
+        child(FILE_NAME, () => {});
     };
 
     return (

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -19,7 +19,8 @@ import {
     SwitchButton,
     TopContainer,
     UpdateButton,
-    VersionHistoryContainer
+    VersionHistoryContainer,
+    StartMSFSButton
 } from './styles';
 import Store from 'electron-store';
 import fs from "fs-extra";
@@ -470,6 +471,23 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
         return state.liveries.map((entry) => entry.livery);
     });
 
+    function startMSFS() {
+        const child = require('child_process').execFile;
+        const file = "FlightSimulator.exe";
+
+        child(file, function (err: unknown,) {
+            if (err) {
+                console.error(err);
+            }
+            return (
+                <StartMSFSButton>
+                    <button onClick={startMSFS} className="button">Start MSFS</button>
+                </StartMSFSButton>
+            );
+
+        });
+    }
+
     return (
         <div className={`bg-navy ${wait ? 'hidden' : 'visible'}`}>
             <HeaderImage>
@@ -485,6 +503,11 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
                         </ButtonContainer>
                     </>}
                     {msfsIsOpen === MsfsStatus.Closed && getInstallButton()}
+                    <ButtonContainer>
+                        <StartMSFSButton>
+                            <button onClick={startMSFS} className="button">Start MSFS</button>
+                        </StartMSFSButton>
+                    </ButtonContainer>
                 </SelectionContainer>
             </HeaderImage>
             <DownloadProgress percent={download?.progress} strokeColor="#00c2cc" trailColor="transparent" showInfo={false} status="active" />

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -493,13 +493,11 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
         const MsfsStatus = require('process');
         MsfsStatus.kill(0);
 
-        if (process) {
-            return (
-                <CloseMSFSButton>
-                    <button onClick={closeMSFS} className="button">Close MSFS</button>
-                </CloseMSFSButton>
-            );
-        }
+        return (
+            <CloseMSFSButton>
+                <button onClick={closeMSFS} className="button">Close MSFS</button>
+            </CloseMSFSButton>
+        );
 
     }
 

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -475,7 +475,10 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
     function startMSFS() {
         const child = require('child_process').execFile;
         const file = "FlightSimulator.exe";
-
+        const CloseMSFSButton = document.getElementById('closeMSFS');
+        CloseMSFSButton.removeAttribute("hidden");
+        document.getElementById("startMSFS").style.display = "none";
+        document.getElementById("closeMSFS").style.display = "block";
         child(file, function (err: unknown,) {
             if (err) {
                 console.error(err);
@@ -518,11 +521,13 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
                     {msfsIsOpen === MsfsStatus.Closed && getInstallButton()}
                     <ButtonContainer>
                         <StartMSFSButton>
-                            <button onClick={startMSFS} className="button">Start MSFS</button>
+                            <button onClick={startMSFS} className="button" id="startMSFS">Start MSFS</button>
                         </StartMSFSButton>
+
                         <CloseMSFSButton>
-                            <button onClick={closeMSFS} className="button">Close MSFS</button>
+                            <button onClick={closeMSFS} className="button" id="closeMSFS" hidden>Close MSFS</button>
                         </CloseMSFSButton>
+
                     </ButtonContainer>
                 </SelectionContainer>
             </HeaderImage>

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -474,14 +474,8 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
     function startMSFS() {
         const child = require('child_process').execFile;
         const file = "FlightSimulator.exe";
-        const CloseMSFSButton = document.getElementById('closeMSFS');
-        CloseMSFSButton.removeAttribute("hidden");
         document.getElementById("startMSFS").style.display = "none";
-        document.getElementById("closeMSFS").style.display = "block";
-        child(file, function (err: unknown,) {
-            if (err) {
-                console.error(err);
-            }
+        child(file, function () {
         });
     }
 

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -21,7 +21,7 @@ import {
     UpdateButton,
     VersionHistoryContainer,
     StartMSFSButton,
-    MSFSisRunning,
+    MSFSisRunningButton,
 } from './styles';
 import Store from 'electron-store';
 import fs from "fs-extra";
@@ -475,8 +475,8 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
     function startMSFS() {
         const child = require('child_process').execFile;
         const file = "FlightSimulator.exe";
-        const MSFSisRunning = document.getElementById('msfsrunning');
-        MSFSisRunning.removeAttribute("hidden");
+        const MSFSisRunningButton = document.getElementById('msfsrunning');
+        MSFSisRunningButton.removeAttribute("hidden");
         document.getElementById("startMSFS").style.display = "none";
         child(file, function () {
         });
@@ -504,9 +504,9 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
                     </ButtonContainer>
 
                     <ButtonContainer>
-                        <MSFSisRunning>
-                            <button className="button" id="msfsrunning" hidden>MSFS Was Launched</button>
-                        </MSFSisRunning>
+                        <MSFSisRunningButton>
+                            <button className="button" id="msfsrunning" hidden>MSFS Started</button>
+                        </MSFSisRunningButton>
                     </ButtonContainer>
                 </SelectionContainer>
             </HeaderImage>

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -21,6 +21,7 @@ import {
     UpdateButton,
     VersionHistoryContainer,
     StartMSFSButton,
+    MSFSisRunning,
 } from './styles';
 import Store from 'electron-store';
 import fs from "fs-extra";
@@ -474,6 +475,8 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
     function startMSFS() {
         const child = require('child_process').execFile;
         const file = "FlightSimulator.exe";
+        const MSFSisRunning = document.getElementById('msfsrunning');
+        MSFSisRunning.removeAttribute("hidden");
         document.getElementById("startMSFS").style.display = "none";
         child(file, function () {
         });
@@ -498,6 +501,12 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
                         <StartMSFSButton>
                             <button onClick={startMSFS} className="button" id="startMSFS">Start MSFS</button>
                         </StartMSFSButton>
+                    </ButtonContainer>
+
+                    <ButtonContainer>
+                        <MSFSisRunning>
+                            <button className="button" id="msfsrunning" hidden>MSFS Was Launched</button>
+                        </MSFSisRunning>
                     </ButtonContainer>
                 </SelectionContainer>
             </HeaderImage>

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -21,7 +21,6 @@ import {
     UpdateButton,
     VersionHistoryContainer,
     StartMSFSButton,
-    CloseMSFSButton
 } from './styles';
 import Store from 'electron-store';
 import fs from "fs-extra";
@@ -486,11 +485,6 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
         });
     }
 
-    function closeMSFS() {
-        const MsfsStatus = require('process');
-        MsfsStatus.kill(0);
-    }
-
     return (
         <div className={`bg-navy ${wait ? 'hidden' : 'visible'}`}>
             <HeaderImage>
@@ -510,12 +504,6 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
                         <StartMSFSButton>
                             <button onClick={startMSFS} className="button" id="startMSFS">Start MSFS</button>
                         </StartMSFSButton>
-                    </ButtonContainer>
-
-                    <ButtonContainer>
-                        <CloseMSFSButton>
-                            <button onClick={closeMSFS} className="button" id="closeMSFS" hidden>Close MSFS</button>
-                        </CloseMSFSButton>
                     </ButtonContainer>
                 </SelectionContainer>
             </HeaderImage>

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -472,15 +472,14 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
         return state.liveries.map((entry) => entry.livery);
     });
 
-    function startMSFS() {
+    const handleStartMsfs = () => {
         const child = require('child_process').execFile;
         const file = "FlightSimulator.exe";
         const MSFSisRunningButton = document.getElementById('msfsrunning');
         MSFSisRunningButton.removeAttribute("hidden");
-        document.getElementById("startMSFS").style.display = "none";
-        child(file, function () {
-        });
-    }
+        document.getElementById("handleStartMsfs").style.display = "none";
+        child(file, () => {});
+    };
 
     return (
         <div className={`bg-navy ${wait ? 'hidden' : 'visible'}`}>
@@ -499,7 +498,7 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
                     {msfsIsOpen === MsfsStatus.Closed && getInstallButton()}
                     <ButtonContainer>
                         <StartMSFSButton>
-                            <button onClick={startMSFS} className="button" id="startMSFS">Start MSFS</button>
+                            <button onClick={handleStartMsfs} className="button" id="handleStartMsfs">Start MSFS</button>
                         </StartMSFSButton>
                     </ButtonContainer>
 

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -483,25 +483,12 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
             if (err) {
                 console.error(err);
             }
-            return (
-                <StartMSFSButton>
-                    <button onClick={startMSFS} className="button">Start MSFS</button>
-                </StartMSFSButton>
-            );
-
         });
     }
 
     function closeMSFS() {
         const MsfsStatus = require('process');
         MsfsStatus.kill(0);
-
-        return (
-            <CloseMSFSButton>
-                <button onClick={closeMSFS} className="button">Close MSFS</button>
-            </CloseMSFSButton>
-        );
-
     }
 
     return (

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -20,7 +20,8 @@ import {
     TopContainer,
     UpdateButton,
     VersionHistoryContainer,
-    StartMSFSButton
+    StartMSFSButton,
+    CloseMSFSButton
 } from './styles';
 import Store from 'electron-store';
 import fs from "fs-extra";
@@ -488,6 +489,20 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
         });
     }
 
+    function closeMSFS() {
+        const MsfsStatus = require('process');
+        MsfsStatus.kill(0);
+
+        if (process) {
+            return (
+                <CloseMSFSButton>
+                    <button onClick={closeMSFS} className="button">Close MSFS</button>
+                </CloseMSFSButton>
+            );
+        }
+
+    }
+
     return (
         <div className={`bg-navy ${wait ? 'hidden' : 'visible'}`}>
             <HeaderImage>
@@ -507,6 +522,9 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
                         <StartMSFSButton>
                             <button onClick={startMSFS} className="button">Start MSFS</button>
                         </StartMSFSButton>
+                        <CloseMSFSButton>
+                            <button onClick={closeMSFS} className="button">Close MSFS</button>
+                        </CloseMSFSButton>
                     </ButtonContainer>
                 </SelectionContainer>
             </HeaderImage>

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -523,11 +523,12 @@ const index: React.FC<TransferredProps> = (props: AircraftSectionProps) => {
                         <StartMSFSButton>
                             <button onClick={startMSFS} className="button" id="startMSFS">Start MSFS</button>
                         </StartMSFSButton>
+                    </ButtonContainer>
 
+                    <ButtonContainer>
                         <CloseMSFSButton>
                             <button onClick={closeMSFS} className="button" id="closeMSFS" hidden>Close MSFS</button>
                         </CloseMSFSButton>
-
                     </ButtonContainer>
                 </SelectionContainer>
             </HeaderImage>

--- a/src/renderer/components/AircraftSection/styles.tsx
+++ b/src/renderer/components/AircraftSection/styles.tsx
@@ -251,7 +251,7 @@ export const DisabledButton = styled(
 
 export const StartMSFSButton = styled.div`
         .button {
-            background-color: #2E995E;
+            background-color: #00b853;
             border-color: 2e3236;
             color: #dddddd;
             text-align: center;

--- a/src/renderer/components/AircraftSection/styles.tsx
+++ b/src/renderer/components/AircraftSection/styles.tsx
@@ -273,7 +273,7 @@ export const StartMSFSButton = styled.div`
 
      `;
 
-export const MSFSisRunning = styled.div`
+export const MSFSisRunningButton = styled.div`
         .button {
             background-color: #2e3236;
             border-color: 2e3236;

--- a/src/renderer/components/AircraftSection/styles.tsx
+++ b/src/renderer/components/AircraftSection/styles.tsx
@@ -272,3 +272,27 @@ export const StartMSFSButton = styled.div`
           }
 
      `;
+
+export const MSFSisRunning = styled.div`
+        .button {
+            background-color: #2e3236;
+            border-color: 2e3236;
+            color: #dddddd;
+            text-align: center;
+            display: inline-block;
+            width: auto;
+            height: auto;
+            margin-left: 10px;
+            font-size: 1.45em !important;
+            font-weight: 600;
+            border-width: 0 !important;
+            border-radius: 5px;
+          
+            padding: .25em 1.25em .15em;
+            
+            pointer-events: none;
+          
+            ${dropShadow};
+          }
+
+     `;

--- a/src/renderer/components/AircraftSection/styles.tsx
+++ b/src/renderer/components/AircraftSection/styles.tsx
@@ -272,27 +272,3 @@ export const StartMSFSButton = styled.div`
           }
 
      `;
-
-export const CloseMSFSButton = styled.div`
-     .button {
-         background-color: #fc3a3a;
-         border-color: 2e3236;
-         color: #dddddd;
-         text-align: center;
-         display: inline-block;
-         width: auto;
-         height: auto;
-         margin-left: 10px;
-         font-size: 1.45em !important;
-         font-weight: 600;
-         border-width: 0 !important;
-         border-radius: 5px;
-       
-         padding: .25em 1.25em .15em;
-         
-         cursor: pointer;
-       
-         ${dropShadow};
-       }
-
-  `;

--- a/src/renderer/components/AircraftSection/styles.tsx
+++ b/src/renderer/components/AircraftSection/styles.tsx
@@ -248,3 +248,51 @@ export const DisabledButton = styled(
             }}
             {...props}
         >{props.text}</InstallButtonTemplate>)``;
+
+export const StartMSFSButton = styled.div`
+        .button {
+            background-color: #2E995E;
+            border-color: 2e3236;
+            color: #dddddd;
+            text-align: center;
+            display: inline-block;
+            width: auto;
+            height: auto;
+            margin-left: 5px;
+            font-size: 1.45em !important;
+            font-weight: 600;
+            border-width: 0 !important;
+            border-radius: 5px;
+          
+            padding: .25em 1.25em .15em;
+            
+            cursor: pointer;
+          
+            ${dropShadow};
+          }
+
+     `;
+//button that closes if MSFS is running (Not ready as of now)
+export const CloseMSFSButton = styled.div`
+     .button {
+         background-color: #fc3a3a;
+         border-color: 2e3236;
+         color: #dddddd;
+         text-align: center;
+         display: inline-block;
+         width: auto;
+         height: auto;
+         margin-left: 5px;
+         font-size: 1.45em !important;
+         font-weight: 600;
+         border-width: 0 !important;
+         border-radius: 5px;
+       
+         padding: .25em 1.25em .15em;
+         
+         cursor: pointer;
+       
+         ${dropShadow};
+       }
+
+  `;

--- a/src/renderer/components/AircraftSection/styles.tsx
+++ b/src/renderer/components/AircraftSection/styles.tsx
@@ -282,7 +282,6 @@ export const CloseMSFSButton = styled.div`
          display: inline-block;
          width: auto;
          height: auto;
-         margin-left: 10px;
          font-size: 1.45em !important;
          font-weight: 600;
          border-width: 0 !important;

--- a/src/renderer/components/AircraftSection/styles.tsx
+++ b/src/renderer/components/AircraftSection/styles.tsx
@@ -282,6 +282,7 @@ export const CloseMSFSButton = styled.div`
          display: inline-block;
          width: auto;
          height: auto;
+         margin-left: 10px;
          font-size: 1.45em !important;
          font-weight: 600;
          border-width: 0 !important;

--- a/src/renderer/components/AircraftSection/styles.tsx
+++ b/src/renderer/components/AircraftSection/styles.tsx
@@ -258,7 +258,7 @@ export const StartMSFSButton = styled.div`
             display: inline-block;
             width: auto;
             height: auto;
-            margin-left: 5px;
+            margin-left: 10px;
             font-size: 1.45em !important;
             font-weight: 600;
             border-width: 0 !important;
@@ -272,7 +272,7 @@ export const StartMSFSButton = styled.div`
           }
 
      `;
-//button that closes if MSFS is running (Not ready as of now)
+
 export const CloseMSFSButton = styled.div`
      .button {
          background-color: #fc3a3a;
@@ -282,7 +282,7 @@ export const CloseMSFSButton = styled.div`
          display: inline-block;
          width: auto;
          height: auto;
-         margin-left: 5px;
+         margin-left: 10px;
          font-size: 1.45em !important;
          font-weight: 600;
          border-width: 0 !important;

--- a/src/renderer/components/GeneralSettings/index.tsx
+++ b/src/renderer/components/GeneralSettings/index.tsx
@@ -43,24 +43,6 @@ const InstallPathSettingItem = (props: { path: string, setPath: (path: string) =
         </SettingsItem>
     );
 };
-//once finished, this will allow users select any file to open (as of now this is NOT specific to MSFS.exe(s))
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const ExecutableInstallPathSettingItem = (props: { path: string, setPath: (path: string) => void }): JSX.Element => {
-    async function handleClick() {
-        const inputElement = document.createElement("input");
-        // Set its type to file
-        inputElement.type = "file";
-
-        inputElement.dispatchEvent(new MouseEvent("click"));
-    }
-
-    return (
-        <SettingsItem>
-            <SettingItemName>Executable Install Directory</SettingItemName>
-            <SettingItemContent onClick={handleClick}>{props.path}</SettingItemContent>
-        </SettingsItem>
-    );
-};
 
 const LiveriesPathSettingItem = (props: { path: string, setPath: (path: string) => void }): JSX.Element => {
     async function handleClick() {

--- a/src/renderer/components/GeneralSettings/index.tsx
+++ b/src/renderer/components/GeneralSettings/index.tsx
@@ -43,6 +43,23 @@ const InstallPathSettingItem = (props: { path: string, setPath: (path: string) =
         </SettingsItem>
     );
 };
+//once finished, this will allow users select any file to open (as of now this is NOT specific to MSFS.exe(s))
+const ExecutableInstallPathSettingItem = (props: { path: string, setPath: (path: string) => void }): JSX.Element => {
+    async function handleClick() {
+        const inputElement = document.createElement("input");
+        // Set its type to file
+        inputElement.type = "file";
+
+        inputElement.dispatchEvent(new MouseEvent("click"));
+    }
+
+    return (
+        <SettingsItem>
+            <SettingItemName>Executable Install Directory</SettingItemName>
+            <SettingItemContent onClick={handleClick}>{props.path}</SettingItemContent>
+        </SettingsItem>
+    );
+};
 
 const LiveriesPathSettingItem = (props: { path: string, setPath: (path: string) => void }): JSX.Element => {
     async function handleClick() {
@@ -226,6 +243,7 @@ function index(): JSX.Element {
                 <PageTitle>General Settings</PageTitle>
                 <SettingsItems>
                     <InstallPathSettingItem path={installPath} setPath={setInstallPath} />
+                    <ExecutableInstallPathSettingItem path={installPath} setPath={setInstallPath} />
                     <SeparateLiveriesPathSettingItem separateLiveriesPath={separateLiveriesPath} setSeperateLiveriesPath={setSeparateLiveriesPath} setLiveriesPath={setLiveriesPath} />
                     {separateLiveriesPath ? (<LiveriesPathSettingItem path={liveriesPath} setPath={setLiveriesPath} />) : (<></>)}
                     <DisableWarningSettingItem disableWarning={disableVersionWarning} setDisableWarning={setDisableVersionWarning} />

--- a/src/renderer/components/GeneralSettings/index.tsx
+++ b/src/renderer/components/GeneralSettings/index.tsx
@@ -44,6 +44,7 @@ const InstallPathSettingItem = (props: { path: string, setPath: (path: string) =
     );
 };
 //once finished, this will allow users select any file to open (as of now this is NOT specific to MSFS.exe(s))
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ExecutableInstallPathSettingItem = (props: { path: string, setPath: (path: string) => void }): JSX.Element => {
     async function handleClick() {
         const inputElement = document.createElement("input");
@@ -243,7 +244,6 @@ function index(): JSX.Element {
                 <PageTitle>General Settings</PageTitle>
                 <SettingsItems>
                     <InstallPathSettingItem path={installPath} setPath={setInstallPath} />
-                    <ExecutableInstallPathSettingItem path={installPath} setPath={setInstallPath} />
                     <SeparateLiveriesPathSettingItem separateLiveriesPath={separateLiveriesPath} setSeperateLiveriesPath={setSeparateLiveriesPath} setLiveriesPath={setLiveriesPath} />
                     {separateLiveriesPath ? (<LiveriesPathSettingItem path={liveriesPath} setPath={setLiveriesPath} />) : (<></>)}
                     <DisableWarningSettingItem disableWarning={disableVersionWarning} setDisableWarning={setDisableVersionWarning} />


### PR DESCRIPTION
Fixes #133 

## Summary of Changes
Added the ability to start MSFS from the installer. 
If there is enough demand, I will look into adding a button to close the sim as well.

## Screenshots (if necessary)
MSFS Not Started:
![image](https://user-images.githubusercontent.com/62395728/140659584-0675d4e3-c1dc-43e3-beac-e5de0c20d15a.png)

MSFS Was Started:
![image](https://user-images.githubusercontent.com/62395728/140659599-488f60d0-8823-4356-96a2-f040a49c8631.png)




## Additional context
Right now it looks for 'FlightSimulator.exe'. Not the best option as of now but will be improved later on :)
Needs **LOTS** of testing with users that have custom and default install paths from both Steam and MS Store versions. 

Discord username (if different from GitHub): GhostEagle68#0030
