### PR TITLE
feat: add a button that opens and closes sidebar

### DIFF
--- a/src/renderer/components/App/SideBar.tsx
+++ b/src/renderer/components/App/SideBar.tsx
@@ -33,6 +33,21 @@ export const SidebarPublisher: React.FC<SidebarPublisherProps> = ({ name, logo, 
     );
 };
 
+export const SidebarCompact: React.FC<SidebarPublisherProps> = ({ name, logo, children }) => {
+    const [expanded, setExpanded] = useState(true);
+
+    return (
+        <>
+            <span onClick={() => setExpanded(old => !old)} className="bg-navy-lighter flex flex-row items-center transform transition-colors duration-300 hover:bg-navy-lightest text-lg text-white pl-3 py-3.5 cursor-pointer">
+                <ChevronDown className={`text-gray-200 transform transition-transform duration-300 ${expanded ? 'rotate-0' : '-rotate-90'}`} size={28} />
+                <img className="ml-1 mr-2" src={logo} alt="" />
+                <span className="text-base text-gray-100">{name}</span>
+            </span>
+            {expanded && children}
+        </>
+    );
+};
+
 type SidebarAddonProps = { addon: Addon, isSelected: boolean, handleSelected: (key: string) => void }
 
 export const SidebarAddon: React.FC<SidebarAddonProps> = ({ addon, isSelected, handleSelected }) => {

--- a/src/renderer/components/App/SideBar.tsx
+++ b/src/renderer/components/App/SideBar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Check, ChevronDown, Download, Refresh } from "tabler-icons-react";
+import { ArrowBarToLeft, Check, ChevronDown, Download, Refresh } from "tabler-icons-react";
 import { useSelector, } from "react-redux";
 import { InstallerStore } from "renderer/redux/store";
 import { InstallStatus } from "renderer/components/AircraftSection";
@@ -33,15 +33,15 @@ export const SidebarPublisher: React.FC<SidebarPublisherProps> = ({ name, logo, 
     );
 };
 
-export const SidebarCompact: React.FC<SidebarPublisherProps> = ({ name, logo, children }) => {
-    const [expanded, setExpanded] = useState(true);
+export const SidebarCompact: React.FC<SidebarPublisherProps> = ({ logo, children }) => {
+    const [expanded, setExpanded] = useState(false);
 
     return (
         <>
-            <span onClick={() => setExpanded(old => !old)} className="bg-navy-lighter flex flex-row items-center transform transition-colors duration-300 hover:bg-navy-lightest text-lg text-white pl-3 py-3.5 cursor-pointer">
-                <ChevronDown className={`text-gray-200 transform transition-transform duration-300 ${expanded ? 'rotate-0' : '-rotate-90'}`} size={28} />
+            <span className="bg-navy-lighter flex flex-row items-end text-lg text-white pl-3 py-3.5">
+                <ArrowBarToLeft onClick={() => setExpanded(old => !old)} className={`text-gray-200 transform cursor-pointer transform ${expanded ? 'rotate-0' : '-rotate-180'}`} size={35} />
                 <img className="ml-1 mr-2" src={logo} alt="" />
-                <span className="text-base text-gray-100">{name}</span>
+                <span className="text-base text-gray-100"></span>
             </span>
             {expanded && children}
         </>

--- a/src/renderer/components/App/index.tsx
+++ b/src/renderer/components/App/index.tsx
@@ -15,7 +15,7 @@ import * as actionTypes from '../../redux/actionTypes';
 import store from '../../redux/store';
 import { SetAddonAndTrackLatestReleaseInfo } from "renderer/redux/types";
 import { Code, Settings } from "tabler-icons-react";
-import { SidebarItem, SidebarAddon, SidebarPublisher } from "renderer/components/App/SideBar";
+import { SidebarItem, SidebarAddon, SidebarPublisher, SidebarCompact } from "renderer/components/App/SideBar";
 import InstallerUpdate from "renderer/components/InstallerUpdate";
 import { WindowButtons } from "renderer/components/WindowActionButtons";
 import { Configuration, Addon, AddonVersion } from "renderer/utils/InstallerConfiguration";
@@ -119,28 +119,29 @@ const App: React.FC<{ configuration: Configuration }> = ({ configuration }) => {
                         </div>
 
                         <div className="h-full pt-14 flex flex-row justify-start">
-                            <PageSider className="w-72 z-40 flex-none bg-navy-medium shadow-2xl">
-                                <div className="h-full flex flex-col divide-y divide-gray-700">
-                                    {
-                                        configuration.publishers.map(publisher => (
-                                            <SidebarPublisher name={publisher.name} logo={publisher.logoUrl}>
-                                                {
-                                                    publisher.addons.map(addon => (
-                                                        <SidebarAddon
-                                                            key={addon.key}
-                                                            addon={addon}
-                                                            isSelected={selectedItem === addon.key}
-                                                            handleSelected={() => setSelectedItem(addon.key)}
-                                                        />
-                                                    ))
-                                                }
-                                            </SidebarPublisher>
-                                        ))
-                                    }
-
-                                    <div className="mt-auto">
+                            <SidebarCompact name={''} logo={''}>
+                                <PageSider className="w-72 z-40 flex-none bg-navy-medium shadow-2xl">
+                                    <div className="h-full flex flex-col divide-y divide-gray-700">
                                         {
-                                            process.env.NODE_ENV === "development" &&
+                                            configuration.publishers.map(publisher => (
+                                                <SidebarPublisher name={publisher.name} logo={publisher.logoUrl}>
+                                                    {
+                                                        publisher.addons.map(addon => (
+                                                            <SidebarAddon
+                                                                key={addon.key}
+                                                                addon={addon}
+                                                                isSelected={selectedItem === addon.key}
+                                                                handleSelected={() => setSelectedItem(addon.key)}
+                                                            />
+                                                        ))
+                                                    }
+                                                </SidebarPublisher>
+                                            ))
+                                        }
+
+                                        <div className="mt-auto">
+                                            {
+                                                process.env.NODE_ENV === "development" &&
                                             <SidebarItem iSelected={selectedItem === 'debug'} onClick={() => setSelectedItem('debug')}>
                                                 <Code className="text-gray-100 ml-2 mr-3" size={24} />
 
@@ -148,19 +149,20 @@ const App: React.FC<{ configuration: Configuration }> = ({ configuration }) => {
                                                     <span className="text-lg text-gray-200 font-semibold">Debug</span>
                                                 </div>
                                             </SidebarItem>
-                                        }
+                                            }
 
-                                        <SidebarItem iSelected={selectedItem === 'settings'} onClick={() => setSelectedItem('settings')}>
-                                            <Settings className="text-gray-100 ml-2 mr-3" size={24} />
+                                            <SidebarItem iSelected={selectedItem === 'settings'} onClick={() => setSelectedItem('settings')}>
+                                                <Settings className="text-gray-100 ml-2 mr-3" size={24} />
 
-                                            <div className="flex flex-col">
-                                                <span className="text-lg text-gray-200 font-semibold">Settings</span>
-                                            </div>
-                                        </SidebarItem>
+                                                <div className="flex flex-col">
+                                                    <span className="text-lg text-gray-200 font-semibold">Settings</span>
+                                                </div>
+                                            </SidebarItem>
+                                        </div>
+
                                     </div>
-
-                                </div>
-                            </PageSider>
+                                </PageSider>
+                            </SidebarCompact>
                             <Content className="overflow-y-scroll bg-navy m-0">
                                 {sectionToShow}
                             </Content>


### PR DESCRIPTION
Fixes #27 

## Summary of Changes
Added a button that expands and closes the addon selection sidebar

## Screenshots (if necessary)
![image](https://user-images.githubusercontent.com/62395728/141862748-f7d1c292-f481-4e9f-9bfd-2eb91c06e5ee.png)
![image](https://user-images.githubusercontent.com/62395728/141862788-4a817bf1-8d50-4041-8a88-c214806003f3.png)

## Additional context

Discord username (if different from GitHub):
