### PR TITLE
feat(UI): change sideBar installStatus icons

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## 2.1.0
 1. [UI] Add ability to change date layout @FoxtrotSierra6829
+1. [UI] Changed the sideBar installStatus icons @GhostEagle68#0030
 
 
 ## 2.0.1

--- a/src/renderer/components/App/SideBar.tsx
+++ b/src/renderer/components/App/SideBar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Check, ChevronDown, Download, Refresh } from "tabler-icons-react";
+import { AlertTriangle, ArrowBarToDown, ChevronDown , CircleCheck, Rotate2 } from "tabler-icons-react";
 import { useSelector, } from "react-redux";
 import { InstallerStore } from "renderer/redux/store";
 import { InstallStatus } from "renderer/components/AircraftSection";
@@ -76,15 +76,15 @@ export const SidebarAddon: React.FC<SidebarAddonProps> = ({ addon, isSelected, h
     const Icon = () => {
         switch (icon) {
             case 'notAvailable':
-                return <Download className="text-gray-700 ml-auto mr-4" size={28} />;
+                return <AlertTriangle className="text-gray-700 ml-auto mr-4" size={28} />;
             case 'install':
-                return <Download className="text-gray-400 ml-auto mr-4" size={28} />;
+                return <ArrowBarToDown className="text-gray-400 ml-auto mr-4" size={28} />;
             case 'installing':
-                return <Refresh className="text-yellow-400 ml-auto mr-4 animate-spin-reverse" size={28} />;
+                return <Rotate2 className="text-yellow-400 ml-auto mr-4 animate-spin-reverse" size={28} />;
             case 'installed':
-                return <Check className="text-green-400 ml-auto mr-4" size={28} />;
+                return <CircleCheck className="text-green-400 ml-auto mr-4" size={28} />;
             case 'update':
-                return <Download className="text-yellow-400 ml-auto mr-4" size={28} />;
+                return <ArrowBarToDown className="text-yellow-400 ml-auto mr-4" size={28} />;
         }
     };
 


### PR DESCRIPTION

Fixes #[issue_no]

## Summary of Changes
Change the installed, installing, install, notAvailable, and update sidebar icons for the addons.

## Screenshots (if necessary)
Before:
![image](https://user-images.githubusercontent.com/62395728/141702065-bdec4e1d-15f0-4d4d-96ca-643d31f3d3fb.png)
![image](https://user-images.githubusercontent.com/62395728/141702388-5295ec8d-9d07-499d-aeb0-9780988bc4f2.png)
![image](https://user-images.githubusercontent.com/62395728/141702114-05ada18f-23f8-4a45-9662-6fd2ec3ee77a.png)


After:
![image](https://user-images.githubusercontent.com/62395728/141701920-94e4b130-4be4-42e3-aeb6-441372f5a616.png)
![image](https://user-images.githubusercontent.com/62395728/141701953-3d813904-3e5c-4772-871b-d97736108e5a.png)
![image](https://user-images.githubusercontent.com/62395728/141701987-41a73758-2e7e-4d88-934e-ecb226566c67.png)



## Additional context

Discord username (if different from GitHub): GhostEagle68#0030
