### PR TITLE
feat: check for updates periodically

### DIFF
--- a/src/common/channels.ts
+++ b/src/common/channels.ts
@@ -10,4 +10,5 @@ export default {
         available: 'update/available',
         downloaded: 'update/downloaded',
     },
+    checkForInstallerUpdate: 'checkForInstallerUpdate'
 };

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -161,7 +161,13 @@ const createWindow = (): void => {
         });
 
         // tell autoupdater to check for updates
-        autoUpdater.checkForUpdates().then();
+        mainWindow.once('show', () => {
+            autoUpdater.checkForUpdates().then();
+        });
+
+        ipcMain.on(channels.checkForInstallerUpdate, () => {
+            autoUpdater.checkForUpdates().then();
+        });
     }
 };
 

--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -112,7 +112,7 @@ export const AircraftSection = (): JSX.Element => {
     const [hiddenAddon, setHiddenAddon] = useState<Addon | undefined>(undefined);
 
     const installedTracks = useAppSelector(state => state.installedTracks);
-    const selectedTracks = useAppSelector(state => state.selectedTrack);
+    const selectedTracks = useAppSelector(state => state.selectedTracks);
     const installStatus = useAppSelector(state => state.installStatus);
 
     const releaseNotes = useAppSelector(state => state.releaseNotes[selectedAddon.key]);

--- a/src/renderer/components/App/index.tsx
+++ b/src/renderer/components/App/index.tsx
@@ -21,6 +21,8 @@ import { store, useAppSelector } from 'renderer/redux/store';
 import { setAddonAndTrackLatestReleaseInfo } from 'renderer/redux/features/latestVersionNames';
 import settings, { useSetting } from 'common/settings';
 import "./index.css";
+import { ipcRenderer } from 'electron';
+import channels from 'common/channels';
 
 const releaseCache = new DataCache<AddonVersion[]>('releases', 1000 * 3600 * 24);
 
@@ -97,6 +99,7 @@ const App = () => {
     }, []);
 
     setInterval(() => {
+        ipcRenderer.send(channels.checkForInstallerUpdate);
         addons.forEach(AddonData.checkForUpdates);
         addons.forEach(fetchLatestVersionNames);
     }, 5 * 60 * 1000);

--- a/src/renderer/components/App/index.tsx
+++ b/src/renderer/components/App/index.tsx
@@ -98,11 +98,16 @@ const App = () => {
         });
     }, []);
 
-    setInterval(() => {
-        ipcRenderer.send(channels.checkForInstallerUpdate);
-        addons.forEach(AddonData.checkForUpdates);
-        addons.forEach(fetchLatestVersionNames);
-    }, 5 * 60 * 1000);
+    useEffect(() => {
+        const updateCheck = setInterval(() => {
+            ipcRenderer.send(channels.checkForInstallerUpdate);
+            addons.forEach(AddonData.checkForUpdates);
+            addons.forEach(fetchLatestVersionNames);
+        }, 5 * 60 * 1000);
+
+        return () => clearInterval(updateCheck);
+    }, []);
+
 
     const [snowRate, setSnowRate] = useState(1000);
     const [seasonalEffects] = useSetting<boolean>('mainSettings.allowSeasonalEffects');

--- a/src/renderer/components/App/index.tsx
+++ b/src/renderer/components/App/index.tsx
@@ -96,6 +96,11 @@ const App = () => {
         });
     }, []);
 
+    setInterval(() => {
+        addons.forEach(AddonData.checkForUpdates);
+        addons.forEach(fetchLatestVersionNames);
+    }, 5 * 60 * 1000);
+
     const [snowRate, setSnowRate] = useState(1000);
     const [seasonalEffects] = useSetting<boolean>('mainSettings.allowSeasonalEffects');
 

--- a/src/renderer/components/App/index.tsx
+++ b/src/renderer/components/App/index.tsx
@@ -108,7 +108,6 @@ const App = () => {
         return () => clearInterval(updateCheck);
     }, []);
 
-
     const [snowRate, setSnowRate] = useState(1000);
     const [seasonalEffects] = useSetting<boolean>('mainSettings.allowSeasonalEffects');
 

--- a/src/renderer/redux/reducer.ts
+++ b/src/renderer/redux/reducer.ts
@@ -17,7 +17,7 @@ export const combinedReducer = combineReducers({
     installStatus: installStatusReducer,
     installedTracks: installedTrackReducer,
     latestVersionNames: latestVersionNamesReducer,
-    selectedTrack: selectedTrackReducer,
+    selectedTracks: selectedTrackReducer,
     warningModal: warningModalReducer,
     releaseNotes: releaseNotesReducer,
     configuration: configurationReducer,


### PR DESCRIPTION
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- requests the latest version names every 5 minutes
- checks for addon updates every 5 minutes (only if the state is UpToDate before, the latest update information is always verified by Fragmenter, this is only to make the update button appear)
- checks for installer updates every 5 minutes