### PR TITLE
fix: install status animation restarting

### DIFF
--- a/src/renderer/components/App/AddonBar.tsx
+++ b/src/renderer/components/App/AddonBar.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, memo } from "react";
 import { Addon, Publisher, PublisherButton } from "renderer/utils/InstallerConfiguration";
 import { shell } from 'electron';
 import * as BootstrapIcons from 'react-bootstrap-icons';
@@ -91,23 +91,6 @@ export const AddonBarItem: FC<AddonBarItemProps> = ({ addon, enabled, selected, 
 
     const dependantStyles = selected ? ` bg-gradient-to-l from-cyan to-blue-500 text-white` : `${enabledUnselectedStyle} ${enabled && 'hover:border-cyan'}`;
 
-    const StatusComponent = (): JSX.Element => {
-        switch (installStatus) {
-            case InstallStatus.UpToDate:
-            case InstallStatus.TrackSwitch:
-            case InstallStatus.GitInstall:
-                return <Check2 className="mt-1.5" size={32}/>;
-            case InstallStatus.DownloadPrep:
-            case InstallStatus.Decompressing:
-            case InstallStatus.Downloading:
-            case InstallStatus.DownloadEnding:
-                return <ArrowRepeat className="mt-0.5 animate-spin" size={32}/>;
-            case InstallStatus.NeedsUpdate:
-                return <CloudArrowDownFill className="mt-2" size={32}/>;
-            default: return <></>;
-        }
-    };
-
     return (
         <div
             className={`w-full relative p-5 flex flex-col justify-between rounded-lg transition duration-200 border-2 ${defaultBorderStyle} ${dependantStyles} ${!enabled && 'opacity-50'} ${enabled ? 'cursor-pointer' : 'cursor-not-allowed'} ${className}`}
@@ -116,11 +99,32 @@ export const AddonBarItem: FC<AddonBarItemProps> = ({ addon, enabled, selected, 
             <h1 className="text-xl text-current font-bold">{addon.aircraftName}</h1>
             <div className="flex flex-row justify-between mt-1">
                 <img className="h-10 w-max" src={selected || darkTheme ? addon.titleImageUrlSelected : addon.titleImageUrl} />
-                <StatusComponent />
+                <AddonBarItemStatus status={installStatus} />
             </div>
         </div>
     );
 };
+
+interface AddonBarItemStatusProps {
+    status: InstallStatus;
+}
+
+const AddonBarItemStatus: FC<AddonBarItemStatusProps> = memo(({ status }) => {
+    switch (status) {
+        case InstallStatus.UpToDate:
+        case InstallStatus.TrackSwitch:
+        case InstallStatus.GitInstall:
+            return <Check2 className="mt-1.5" size={32}/>;
+        case InstallStatus.DownloadPrep:
+        case InstallStatus.Decompressing:
+        case InstallStatus.Downloading:
+        case InstallStatus.DownloadEnding:
+            return <ArrowRepeat className="mt-0.5 animate-spin" size={32}/>;
+        case InstallStatus.NeedsUpdate:
+            return <CloudArrowDownFill className="mt-2" size={32}/>;
+        default: return <></>;
+    }
+});
 
 interface AddonBarPublisherButtonProps {
     button: PublisherButton,


### PR DESCRIPTION
## Summary of Changes
Fixed a bug where the install status animation would reset when the store was updated and the `AddonBarItem` component was subsequently re-rendered.

## Screenshots (if necessary)
### Before

https://user-images.githubusercontent.com/19419678/150696895-894b81f0-2cae-4239-9a3c-2c447dcad153.mp4

### After

https://user-images.githubusercontent.com/19419678/150696902-78a84e5b-e473-464d-8e86-83cb51624351.mp4




## Additional context
Discord username (if different from GitHub): MikeRoma # 0001
