### PR TITLE
feat: Update a32nx header image

### DIFF
--- a/src/renderer/components/AircraftSection/index.tsx
+++ b/src/renderer/components/AircraftSection/index.tsx
@@ -805,7 +805,7 @@ export const AircraftSection = (): JSX.Element => {
                                 <div
                                     className="h-1/2 relative bg-cover bg-center"
                                     style={{
-                                        backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.6)), url(${selectedAddon.backgroundImageUrls[0]})`,
+                                        backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.3)), url(${selectedAddon.backgroundImageUrls[0]})`,
                                     }}
                                 >
                                     <div className="absolute bottom-0 left-0 flex flex-row items-end justify-between p-6 w-full">

--- a/src/renderer/data.ts
+++ b/src/renderer/data.ts
@@ -35,7 +35,7 @@ export const defaultConfiguration: Configuration = {
                     enabled: true,
                     menuIconUrl: A320NoseSVG,
                     // TODO: Change this
-                    backgroundImageUrls: ['https://flybywiresim.b-cdn.net/installer/media-assets/addon-headers/fbw-a32nx/0.png'],
+                    backgroundImageUrls: ['https://flybywiresim.b-cdn.net/installer/media-assets/addon-headers/fbw-a32nx/1.png'],
                     shortDescription: 'Airbus A320neo Series',
                     description: 'The A320neo (new engine option) is one of many upgrades introduced by Airbus to help maintain ' +
                         'its A320 product line’s position as the world’s most advanced and fuel-efficient single-aisle ' +


### PR DESCRIPTION

Fixes #[issue_no]

## Summary of Changes
-Added new A32NX header image
-Reduced opacity to fit the image

## Screenshots (if necessary)
Before: 
![image](https://user-images.githubusercontent.com/62395728/157537730-2a3e58f4-9633-4184-912d-02b41b23b83a.png)
After: 
![image](https://user-images.githubusercontent.com/62395728/157537765-aaff2aa1-080f-47c4-9167-66ae94211f6c.png)


## Additional context
N/A

Discord username (if different from GitHub): GhostEagle68#0030
