### PR TITLE
chore: Make msfs alive/mcdu warning more obvious for users

### DIFF
--- a/src/renderer/components/AddonSection/ActiveStateText.tsx
+++ b/src/renderer/components/AddonSection/ActiveStateText.tsx
@@ -4,7 +4,9 @@ import React, { FC } from "react";
 import { useAppSelector } from "renderer/redux/store";
 
 const StateText: FC = ({ children }) => (
-    <div className="text-white text-3xl font-bold">{children}</div>
+    <div className="flex flex-col px-3 py-2 rounded-sm-md bg-red border-transparent border-2">
+        <div className="text-white text-3xl font-bold">{children}</div>
+    </div>
 );
 
 interface ActiveStateProps {


### PR DESCRIPTION
<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Please Close MSFS and Please Close MCDU Server are often not spotted by users leading to support tickets on discord. Added a red bg behind the text to make it stand out and be more obvious, a longer term solution would be making this warning more obvious in terms of placement but that can be a longer-term fix vs this. 

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
![electron_xwyORWTwwV](https://user-images.githubusercontent.com/15316958/169641640-365013ff-a34b-4c4a-bfb8-cccdfa2d18d2.png)
![electron_AqCUeRXChJ](https://user-images.githubusercontent.com/15316958/169641644-0ffc15be-ed81-4ebf-8bda-3bd57e4c0d7b.png)

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): 2Cas#1022
