### PR TITLE
fix: only catch websocket ports as MCDU Server

### DIFF
--- a/.github/CHANGELOG.yaml
+++ b/.github/CHANGELOG.yaml
@@ -9,6 +9,11 @@
 
 
 releases:
+  - name: 3.1.1
+    changes:
+      - title: Only detect websocket ports as MCDU Server
+        categories: [Logic]
+        authors: [FoxtrotSierra]
   - name: 3.1.0
     changes:
       - title: Add Salty Simulations 74S

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fbw-installer",
-  "version": "3.1.0-dev.1",
+  "version": "3.1.1-dev.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fbw-installer",
-      "version": "3.1.0-dev.1",
+      "version": "3.1.1-dev.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@ant-design/icons": "^4.4.0",
@@ -42,7 +42,8 @@
         "simplebar-react": "^2.3.0",
         "styled-components": "^5.2.1",
         "tabler-icons-react": "~1.33.0",
-        "walkdir": "^0.4.1"
+        "walkdir": "^0.4.1",
+        "ws": "^8.7.0"
       },
       "devDependencies": {
         "@babel/core": "^7.12.13",
@@ -66,6 +67,7 @@
         "@types/styled-components": "^5.1.7",
         "@types/webpack": "^5.28.0",
         "@types/webpack-env": "^1.16.3",
+        "@types/ws": "^8.5.3",
         "@typescript-eslint/eslint-plugin": "^4.14.2",
         "@typescript-eslint/parser": "^4.14.2",
         "@webpack-cli/serve": "^1.6.0",
@@ -102,6 +104,10 @@
         "webpack": "^5.62.1",
         "webpack-cli": "^4.9.1",
         "webpack-dev-server": "^4.4.0"
+      },
+      "optionalDependencies": {
+        "bufferutil": "^4.0.6",
+        "utf-8-validate": "^5.0.9"
       }
     },
     "node_modules/@ant-design/colors": {
@@ -2641,6 +2647,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/@types/ws": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.2.tgz",
@@ -4186,6 +4201,19 @@
       "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
       "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
       "dev": true
+    },
+    "node_modules/bufferutil": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.6.tgz",
+      "integrity": "sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/builder-util": {
       "version": "22.13.1",
@@ -12072,6 +12100,17 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-loader": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/node-loader/-/node-loader-1.0.2.tgz",
@@ -19471,6 +19510,19 @@
       "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
       "dev": true
     },
+    "node_modules/utf-8-validate": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.9.tgz",
+      "integrity": "sha512-Yek7dAy0v3Kl0orwMlvi7TPtiCNrdfHNd7Gcc/pLq4BLXqfAmd0J7OWMizUQnTTJsyjKn02mU7anqwfmUP4J8Q==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/utf8-byte-length": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
@@ -20242,10 +20294,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-      "dev": true,
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
+      "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -22458,6 +22509,15 @@
       "integrity": "sha512-9gtOPPkfyNoEqCQgx4qJKkuNm/x0R2hKR7fdl7zvTJyHnIisuE/LfvXOsYWL0o3qq6uiBnKZNNNzi3l0y/X+xw==",
       "dev": true
     },
+    "@types/ws": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/yargs": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.2.tgz",
@@ -23627,6 +23687,15 @@
       "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
       "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
       "dev": true
+    },
+    "bufferutil": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.6.tgz",
+      "integrity": "sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==",
+      "optional": true,
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
     },
     "builder-util": {
       "version": "22.13.1",
@@ -29543,6 +29612,12 @@
       "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
+    "node-gyp-build": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
+      "optional": true
+    },
     "node-loader": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/node-loader/-/node-loader-1.0.2.tgz",
@@ -35160,6 +35235,15 @@
         "prepend-http": "^2.0.0"
       }
     },
+    "utf-8-validate": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.9.tgz",
+      "integrity": "sha512-Yek7dAy0v3Kl0orwMlvi7TPtiCNrdfHNd7Gcc/pLq4BLXqfAmd0J7OWMizUQnTTJsyjKn02mU7anqwfmUP4J8Q==",
+      "optional": true,
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
+    },
     "utf8-byte-length": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
@@ -35717,10 +35801,9 @@
       }
     },
     "ws": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-      "dev": true,
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
+      "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
       "requires": {}
     },
     "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fbw-installer",
   "productName": "FlyByWire Installer",
-  "version": "3.1.0-dev.1",
+  "version": "3.1.1-dev.1",
   "description": "Desktop application to install and customize FlyByWire addons",
   "main": "webpack/main/main.js",
   "scripts": {
@@ -65,6 +65,7 @@
     "@types/styled-components": "^5.1.7",
     "@types/webpack": "^5.28.0",
     "@types/webpack-env": "^1.16.3",
+    "@types/ws": "^8.5.3",
     "@typescript-eslint/eslint-plugin": "^4.14.2",
     "@typescript-eslint/parser": "^4.14.2",
     "@webpack-cli/serve": "^1.6.0",
@@ -136,11 +137,16 @@
     "simplebar-react": "^2.3.0",
     "styled-components": "^5.2.1",
     "tabler-icons-react": "~1.33.0",
-    "walkdir": "^0.4.1"
+    "walkdir": "^0.4.1",
+    "ws": "^8.7.0"
   },
   "lint-staged": {
     "*.{ts,tsx}": [
       "npm run lint:fix"
     ]
+  },
+  "optionalDependencies": {
+    "bufferutil": "^4.0.6",
+    "utf-8-validate": "^5.0.9"
   }
 }

--- a/src/renderer/utils/McduServer.ts
+++ b/src/renderer/utils/McduServer.ts
@@ -1,19 +1,24 @@
-import net from "net";
+import WebSocket from 'ws';
 
 export class McduServer {
-
     static async isRunning(): Promise<boolean> {
         return new Promise((resolve) => {
-            const socket = net.connect(8380);
+            const McduServerPort = 8380;
 
-            socket.on('connect', () => {
-                resolve(true);
-                socket.destroy();
-            });
-            socket.on('error', () => {
+            const url = `ws://127.0.0.1:${McduServerPort}`;
+
+            const socket = new WebSocket(url);
+
+            socket.onerror = () => {
                 resolve(false);
-                socket.destroy();
-            });
+                socket.close();
+            };
+
+            socket.onopen = () => {
+                resolve(true);
+                socket.close();
+            };
+
         });
     }
 


### PR DESCRIPTION
Fixes #378 
- note: other websocket connections on port 8380 are still recognized as the MCDU server
