### PR TITLE
feat: check and warning for installed incompatible add-ons

### DIFF
--- a/.github/CHANGELOG.yaml
+++ b/.github/CHANGELOG.yaml
@@ -9,7 +9,7 @@
 
 
 releases:
-  - - name: 3.2.3
+  - - name: 3.3.4
       changes:
         - title: Added check for incompatible add-ons
           categories: [ Addons ]

--- a/.github/CHANGELOG.yaml
+++ b/.github/CHANGELOG.yaml
@@ -9,251 +9,256 @@
 
 
 releases:
+  - - name: 3.2.3
+      changes:
+        - title: Added check for incompatible add-ons
+          categories: [ Addons ]
+          authors: [ Cdr_Maverick ]
   - name: 3.2.2
     changes:
       - title: Update dependency to mitigate potential security issue
-        categories: [Core]
-        authors: [holland]
+        categories: [ Core ]
+        authors: [ holland ]
   - name: 3.2.1
     changes:
       - title: Fix detection of A32NX experimental version as development versions
-        categories: [Addons]
-        authors: [FoxtrotSierra]
+        categories: [ Addons ]
+        authors: [ FoxtrotSierra ]
   - name: 3.2.0
     changes:
       - title: Add FlyByWire Simulations SimBridge
-        categories: [Addons]
-        authors: [holland, Erick]
+        categories: [ Addons ]
+        authors: [ holland, Erick ]
       - title: Add support for addon background services
-        categories: [Core]
-        authors: [holland]
+        categories: [ Core ]
+        authors: [ holland ]
       - title: Improve UI for open applications preventing addon install, update or removal
-        categories: [UI]
-        authors: [holland]
+        categories: [ UI ]
+        authors: [ holland ]
       - title: Add SimBridge configuration UI
-        categories: [Addons]
-        authors: [holland, Erick]
+        categories: [ Addons ]
+        authors: [ holland, Erick ]
       - title: Add customisable temporary folder setting
-        categories: [Logic]
-        authors: [marinofranz, FoxtrotSierra]
+        categories: [ Logic ]
+        authors: [ marinofranz, FoxtrotSierra ]
   - name: 3.1.0
     changes:
       - title: Add Salty Simulations 74S
-        categories: [Addons]
-        authors: [Ninjo, FoxtrotSierra]
+        categories: [ Addons ]
+        authors: [ Ninjo, FoxtrotSierra ]
       - title: Fix installer crashing due to inexisting page
-        categories: [Core]
-        authors: [FoxtrotSierra]
+        categories: [ Core ]
+        authors: [ FoxtrotSierra ]
       - title: Prevent uninstalling while MSFS is open
-        categories: [Logic]
-        authors: [FoxtrotSierra]
+        categories: [ Logic ]
+        authors: [ FoxtrotSierra ]
       - title: Prevent updating or uninstalling while MCDU Server is running
-        categories: [Logic]
-        authors: [FoxtrotSierra]
+        categories: [ Logic ]
+        authors: [ FoxtrotSierra ]
       - title: Fix smaller design issues on ≤1080p
-        categories: [UI]
-        authors: [holland]
+        categories: [ UI ]
+        authors: [ holland ]
   - name: 3.0.0
     changes:
       - title: Fallback to full install after too many retries on a module
-        categories: [Fragmenter]
-        authors: [FoxtrotSierra]
+        categories: [ Fragmenter ]
+        authors: [ FoxtrotSierra ]
       - title: Complete redesign of the installer UI
-        categories: [UI]
-        authors: [holland, Erick, Kevin, FoxtrotSierra, GhostEagle68]
+        categories: [ UI ]
+        authors: [ holland, Erick, Kevin, FoxtrotSierra, GhostEagle68 ]
       - title: Add ReleaseNotes Tab
-        categories: [Features]
-        authors: [Erick]
+        categories: [ Features ]
+        authors: [ Erick ]
       - title: Add publisher quicklinks to the sidebar
-        categories: [UX]
-        authors: [holland, Erick, GhostEagle68]
+        categories: [ UX ]
+        authors: [ holland, Erick, GhostEagle68 ]
       - title: Add autostart functionality
-        categories: [Features]
-        authors: [Erick]
+        categories: [ Features ]
+        authors: [ Erick ]
       - title: Add uninstall functionality
-        categories: [Logic]
-        authors: [FoxtrotSierra]
+        categories: [ Logic ]
+        authors: [ FoxtrotSierra ]
       - title: Fix only last started download abortable on parallel downloads
-        categories: [Logic]
-        authors: [FoxtrotSierra]
+        categories: [ Logic ]
+        authors: [ FoxtrotSierra ]
       - title: Search for updates every 5 minutes
-        categories: [Logic]
-        authors: [FoxtrotSierra]
+        categories: [ Logic ]
+        authors: [ FoxtrotSierra ]
   - name: 2.2.2
     changes:
       - title: Enable experimental version for A32NX
-        categories: [Addons]
-        authors: [holland]
+        categories: [ Addons ]
+        authors: [ holland ]
   - name: 2.2.1
     changes:
       - title: KFBW is now visible to everyone
-        categories: [Addons]
-        authors: [FoxtrotSierra]
+        categories: [ Addons ]
+        authors: [ FoxtrotSierra ]
   - name: 2.2.0
     changes:
       - title: Prepare Installer to be able to handle multiple addons
-        categories: [Logic]
-        authors: [FoxtrotSierra]
+        categories: [ Logic ]
+        authors: [ FoxtrotSierra ]
   - name: 2.1.1
     changes:
       - title: Fix error during configuration of community directory
-        categories: [Logic]
-        authors: [FoxtrotSierra]
+        categories: [ Logic ]
+        authors: [ FoxtrotSierra ]
       - title: Disable experimental version for A32NX
-        categories: [Addons]
-        authors: [FoxtrotSierra]
+        categories: [ Addons ]
+        authors: [ FoxtrotSierra ]
   - name: 2.1.0
     changes:
       - title: Add ability to change date layout
-        categories: [UX]
-        authors: [FoxtrotSierra]
+        categories: [ UX ]
+        authors: [ FoxtrotSierra ]
       - title: Add progress bar to taskbar tab to show installation progress
-        categories: [UX]
-        authors: [Erick]
+        categories: [ UX ]
+        authors: [ Erick ]
       - title: Add ability to show third party licenses
-        categories: [Logic]
-        authors: [nistei]
+        categories: [ Logic ]
+        authors: [ nistei ]
       - title: Add Synaptic Simulations A22X placeholder
-        categories: [Addons]
-        authors: [MikeRomaa]
+        categories: [ Addons ]
+        authors: [ MikeRomaa ]
   - name: 2.0.1
     changes:
       - title: Fix error during configuration of settings on first installation
-        categories: [Logic]
-        authors: [nistei]
+        categories: [ Logic ]
+        authors: [ nistei ]
       - title: Change link to experimental guide
-        categories: [Addons]
-        authors: [FoxtrotSierra]
+        categories: [ Addons ]
+        authors: [ FoxtrotSierra ]
   - name: 2.0.0
     changes:
       - title: Installation method changed from Electron-Forge/Squirel to electron-builder/NSIS to prevent future memory leaks during update
-        categories: [Logic]
-        authors: [holland, FoxtrotSierra]
+        categories: [ Logic ]
+        authors: [ holland, FoxtrotSierra ]
       - title: Remove converted livery packages if conversion failed
-        categories: [Logic]
-        authors: [holland]
+        categories: [ Logic ]
+        authors: [ holland ]
       - title: "Rename #help to #support to adopt current Discord channel naming"
-        categories: [UI]
-        authors: [SjotgunSjonnie, FoxtrotSierra]
+        categories: [ UI ]
+        authors: [ SjotgunSjonnie, FoxtrotSierra ]
       - title: Request the user to set 'Community' folder manually if it cannot be found, fixes error message
-        categories: [Logic]
-        authors: [FoxtrotSierra]
+        categories: [ Logic ]
+        authors: [ FoxtrotSierra ]
       - title: Update 'Experimental' version text for A32NX
-        categories: [Addons]
-        authors: [FoxtrotSierra]
+        categories: [ Addons ]
+        authors: [ FoxtrotSierra ]
   - name: 1.2.0
     changes:
       - title: Complete redesign of the installer
-        categories: [UI]
-        authors: [holland, FoxtrotSierra]
+        categories: [ UI ]
+        authors: [ holland, FoxtrotSierra ]
       - title: Add livery conversion tool
-        categories: [Logic]
-        authors: [holland]
+        categories: [ Logic ]
+        authors: [ holland ]
       - title: Cleanup of old temporary directories on installer close and startup
-        categories: [Logic]
-        authors: [nistei]
+        categories: [ Logic ]
+        authors: [ nistei ]
   - name: 1.1.4
     changes:
       - title: Improved error prevention while downloading an update
-        categories: [Logic]
-        authors: [nistei]
+        categories: [ Logic ]
+        authors: [ nistei ]
       - title: Fix click on cancel causing a retry
-        categories: [Logic]
-        authors: [nistei]
+        categories: [ Logic ]
+        authors: [ nistei ]
   - name: 1.1.3
     changes:
       - title: Fix downloads failing in encrypted directories
-        categories: [Logic]
-        authors: [nistei]
+        categories: [ Logic ]
+        authors: [ nistei ]
       - title: Add retries for failed installs
-        categories: [Logic]
-        authors: [nistei]
+        categories: [ Logic ]
+        authors: [ nistei ]
       - title: Add "Experimental" version for A32NX
-        categories: [Addons]
-        authors: [holland]
+        categories: [ Addons ]
+        authors: [ holland ]
   - name: 1.1.1
     changes:
       - title: Fix full downloads broken for some users
-        categories: [Logic]
-        authors: [nistei]
+        categories: [ Logic ]
+        authors: [ nistei ]
   - name: 1.1.0
     changes:
       - title: Prevent text selection
-        categories: [UI]
-        authors: [FoxtrotSierra]
+        categories: [ UI ]
+        authors: [ FoxtrotSierra ]
       - title: Prevent image dragging
-        categories: [UI]
-        authors: [FoxtrotSierra]
+        categories: [ UI ]
+        authors: [ FoxtrotSierra ]
       - title: Disable preselecting different versions while downloading
-        categories: [Logic]
-        authors: [FoxtrotSierra]
+        categories: [ Logic ]
+        authors: [ FoxtrotSierra ]
       - title: Add Windows notification when download complete
-        categories: [UX]
-        authors: [FoxtotSierra]
+        categories: [ UX ]
+        authors: [ FoxtotSierra ]
       - title: Add changelog for the installer
-        categories: [UX]
-        authors: [FoxtrotSierra]
+        categories: [ UX ]
+        authors: [ FoxtrotSierra ]
       - title: Fix button styling in settings menu
-        categories: [UI]
-        authors: [FoxtrotSierra]
+        categories: [ UI ]
+        authors: [ FoxtrotSierra ]
       - title: Add report issue button at top right corner of installer
-        categories: [UX]
-        authors: [Armankir]
+        categories: [ UX ]
+        authors: [ Armankir ]
       - title: Improved scrollbar color for eased visibility
-        categories: [UI]
-        authors: [Armankir]
+        categories: [ UI ]
+        authors: [ Armankir ]
       - title: New version selector UI
-        categories: [UI]
-        authors: [Marcsoler, Falcon]
+        categories: [ UI ]
+        authors: [ Marcsoler, Falcon ]
       - title: Add warning message for experimental versions
-        categories: [UX]
-        authors: [Falcon]
+        categories: [ UX ]
+        authors: [ Falcon ]
       - title: Implement modular download
-        categories: [Logic]
-        authors: [nistei]
+        categories: [ Logic ]
+        authors: [ nistei ]
       - title: Fix background image remaining black
-        categories: [UI]
-        authors: [FoxtrotSierra]
+        categories: [ UI ]
+        authors: [ FoxtrotSierra ]
       - title: Fix window icon on hover
-        categories: [UI]
-        authors: [FoxtrotSierra]
+        categories: [ UI ]
+        authors: [ FoxtrotSierra ]
       - title: Fix unknown download state after switching tabs
-        categories: [Logic]
-        authors: [FoxtrotSierra]
+        categories: [ Logic ]
+        authors: [ FoxtrotSierra ]
   - name: 1.0.5
     changes:
       - title: Disable offline modal due to issues
-        categories: [UX]
-        authors: [Falcon]
+        categories: [ UX ]
+        authors: [ Falcon ]
   - name: 1.0.4
     changes:
       - title: Change CDN (download server)
-        categories: [Logic]
-        authors: [Falcon]
+        categories: [ Logic ]
+        authors: [ Falcon ]
   - name: 1.0.3
     changes:
       - title: Improve 'MSFS is open' logic
-        categories: [Logic]
-        authors: [Falcon]
+        categories: [ Logic ]
+        authors: [ Falcon ]
   - name: 1.0.2
     changes:
       - title: Kill unnecessary child processes
-        categories: [Logic]
-        authors: [nistei]
+        categories: [ Logic ]
+        authors: [ nistei ]
   - name: 1.0.1
     changes:
       - title: Fix side menu install state - @Benjozork (Benjamin Dupont)
-        categories: [Logic]
-        authors: [holland]
+        categories: [ Logic ]
+        authors: [ holland ]
       - title: Change A380X status from 'not installed' to 'not available'
-        categories: [UI]
-        authors: [Falcon]
+        categories: [ UI ]
+        authors: [ Falcon ]
       - title: More accurate 'is installed' logic
-        categories: [Logic]
-        authors: [Falcon]
+        categories: [ Logic ]
+        authors: [ Falcon ]
       - title: Change version name from 'FBW' to 'Custom FBW'
-        categories: [UI]
-        authors: [Falcon]
+        categories: [ UI ]
+        authors: [ Falcon ]
   - name: 1.0.0
     changes:
       - title: Initial Release

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "react-windows-controls": "^1.1.1",
     "redux": "^4.0.5",
     "remark-gfm": "^2.0.0",
+    "semver": "7.3.5",
     "simplebar-react": "^2.3.0",
     "styled-components": "^5.2.1",
     "tabler-icons-react": "~1.33.0",

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -183,7 +183,11 @@ const schema: Schema<Settings> = {
                 type: "boolean",
                 default: true,
             },
-            msfsPackagePath: {
+            msfsCommunityPath: {
+                type: "string",
+                default: defaultCommunityDir(),
+            },
+            installPath: {
                 type: "string",
                 default: defaultCommunityDir(),
             },

--- a/src/renderer/actions/install-path.utils.tsx
+++ b/src/renderer/actions/install-path.utils.tsx
@@ -2,17 +2,37 @@ import settings from "common/settings";
 import { Directories } from "renderer/utils/Directories";
 import { dialog } from "@electron/remote";
 
-export const setupInstallPath = async (): Promise<string> => {
-    const currentPath = Directories.community();
+export const setupMsfsCommunityPath = async (): Promise<string> => {
+    const currentPath = Directories.installLocation();
 
     const path = await dialog.showOpenDialog({
-        title: 'Select your community directory',
+        title: 'Select your MSFS community directory',
         defaultPath: typeof currentPath === 'string' ? currentPath : '',
         properties: ['openDirectory'],
     });
 
     if (path.filePaths[0]) {
-        settings.set('mainSettings.msfsPackagePath', path.filePaths[0]);
+        settings.set('mainSettings.installPath', path.filePaths[0]);
+        if (!settings.get('mainSettings.separateLiveriesPath')) {
+            settings.set('mainSettings.liveriesPath', path.filePaths[0]);
+        }
+        return path.filePaths[0];
+    } else {
+        return "";
+    }
+};
+
+export const setupInstallPath = async (): Promise<string> => {
+    const currentPath = Directories.installLocation();
+
+    const path = await dialog.showOpenDialog({
+        title: 'Select your install directory',
+        defaultPath: typeof currentPath === 'string' ? currentPath : '',
+        properties: ['openDirectory'],
+    });
+
+    if (path.filePaths[0]) {
+        settings.set('mainSettings.installPath', path.filePaths[0]);
         if (!settings.get('mainSettings.separateLiveriesPath')) {
             settings.set('mainSettings.liveriesPath', path.filePaths[0]);
         }

--- a/src/renderer/actions/install-path.utils.tsx
+++ b/src/renderer/actions/install-path.utils.tsx
@@ -12,10 +12,7 @@ export const setupMsfsCommunityPath = async (): Promise<string> => {
     });
 
     if (path.filePaths[0]) {
-        settings.set('mainSettings.installPath', path.filePaths[0]);
-        if (!settings.get('mainSettings.separateLiveriesPath')) {
-            settings.set('mainSettings.liveriesPath', path.filePaths[0]);
-        }
+        settings.set('mainSettings.msfsCommunityPath', path.filePaths[0]);
         return path.filePaths[0];
     } else {
         return "";

--- a/src/renderer/components/AddonSection/MyInstall/index.tsx
+++ b/src/renderer/components/AddonSection/MyInstall/index.tsx
@@ -45,10 +45,10 @@ export const MyInstall: FC<MyInstallProps> = ({ addon }) => {
         let fullPath;
         switch (def.location.in) {
             case 'community':
-                fullPath = Directories.inCommunity(def.location.path);
+                fullPath = Directories.inInstallLocation(def.location.path);
                 break;
             case 'package':
-                fullPath = Directories.inCommunityPackage(addon, def.location.path);
+                fullPath = Directories.inInstallPackage(addon, def.location.path);
                 break;
             case "packageCache":
                 fullPath = Directories.inPackageCache(addon, def.location.path);

--- a/src/renderer/components/AddonSection/StateSection.tsx
+++ b/src/renderer/components/AddonSection/StateSection.tsx
@@ -42,8 +42,11 @@ export const StateSection: FC<StateSectionProps> = ({ publisher, addon }) => {
 
     return (
         <>
-            <BackgroundServiceBanner publisher={publisher} addon={addon} installState={dependencyAddonInstallState ?? addonInstallState} />
-            <DownloadProgressBanner addon={addon} installState={dependencyAddonInstallState ?? addonInstallState} download={dependencyAddonDownload ?? addonDownload} isDependency={isInstallingDependency} />
+            <BackgroundServiceBanner publisher={publisher} addon={addon}
+                installState={dependencyAddonInstallState ?? addonInstallState}/>
+            <DownloadProgressBanner addon={addon} installState={dependencyAddonInstallState ?? addonInstallState}
+                download={dependencyAddonDownload ?? addonDownload}
+                isDependency={isInstallingDependency}/>
         </>
     );
 };
@@ -97,7 +100,7 @@ const BackgroundServiceBanner: FC<BackgroundServiceBannerProps> = ({ publisher, 
         const bgAccentColor = isRunning ? 'bg-utility-green' : 'bg-gray-500';
 
         const handleClickAutostart = () => showModal(
-            <AutostartDialog app={app} addon={addon} publisher={publisher} isPrompted={false} />,
+            <AutostartDialog app={app} addon={addon} publisher={publisher} isPrompted={false}/>,
         );
 
         const handleStartStop = async () => {
@@ -105,7 +108,7 @@ const BackgroundServiceBanner: FC<BackgroundServiceBannerProps> = ({ publisher, 
                 const md = `Are you sure you want to shut down **${addon.name}**?. All related functionality will no longer be available.`;
 
                 const doStop = await showModalAsync(
-                    <PromptModal title={"Are you sure?"} bodyText={md} confirmColor={ButtonType.Danger} />,
+                    <PromptModal title={"Are you sure?"} bodyText={md} confirmColor={ButtonType.Danger}/>,
                 );
 
                 if (doStop) {
@@ -122,9 +125,9 @@ const BackgroundServiceBanner: FC<BackgroundServiceBannerProps> = ({ publisher, 
                     <div className="flex gap-x-7 items-center">
                         {
                             isRunning ? (
-                                <Activity size={32} className={`text-utility-green fill-current animate-pulse`} />
+                                <Activity size={32} className={`text-utility-green fill-current animate-pulse`}/>
                             ) : (
-                                <Activity size={32} className={`text-gray-500 fill-current`} />
+                                <Activity size={32} className={`text-gray-500 fill-current`}/>
                             )
                         }
 
@@ -136,17 +139,20 @@ const BackgroundServiceBanner: FC<BackgroundServiceBannerProps> = ({ publisher, 
 
                     <div className="flex gap-x-14 items-center">
                         {(addon.backgroundService.enableAutostartConfiguration ?? true) && (
-                            <span className="flex items-center gap-x-3.5 text-3xl text-quasi-white hover:text-cyan cursor-pointer" onClick={handleClickAutostart}>
-                                <Gear size={22} />
+                            <span
+                                className="flex items-center gap-x-3.5 text-3xl text-quasi-white hover:text-cyan cursor-pointer"
+                                onClick={handleClickAutostart}>
+                                <Gear size={22}/>
                                 Autostart...
                             </span>
                         )}
 
-                        <Button className="w-64" type={ButtonType.Neutral} onClick={handleStartStop}>{isRunning ? 'Stop' : 'Start'}</Button>
+                        <Button className="w-64" type={ButtonType.Neutral}
+                            onClick={handleStartStop}>{isRunning ? 'Stop' : 'Start'}</Button>
                     </div>
                 </StateContainer>
 
-                <ProgressBar className={bgAccentColor} value={100} animated={isRunning} />
+                <ProgressBar className={bgAccentColor} value={100} animated={isRunning}/>
             </div>
 
         );
@@ -175,7 +181,7 @@ const DownloadProgressBanner: FC<DownloadProgressBannerProps> = ({ addon, instal
     let progressBarValue;
     switch (installState.status) {
         case InstallStatus.DownloadPrep:
-            stateIcon = <Download size={40} className="text-white mr-6" />;
+            stateIcon = <Download size={40} className="text-white mr-6"/>;
             stateText = <SmallStateText>Preparing update</SmallStateText>;
             progressBarBg = 'bg-cyan';
             progressBarValue = 0;
@@ -191,7 +197,7 @@ const DownloadProgressBanner: FC<DownloadProgressBannerProps> = ({ addon, instal
                         className="text-gray-300 ml-3">part {download.progress.splitPartIndex + 1}/{download.progress.splitPartCount}</span>
                     : null;
 
-                stateIcon = <Download size={40} className="text-white mr-6" />;
+                stateIcon = <Download size={40} className="text-white mr-6"/>;
                 stateText = <SmallStateText>{`Downloading`}{part}</SmallStateText>;
                 progressBarBg = 'bg-cyan';
             }
@@ -263,7 +269,8 @@ const DownloadProgressBanner: FC<DownloadProgressBannerProps> = ({ addon, instal
 
     let moduleStateText;
     if (download.module && installState.status !== InstallStatus.DownloadCanceled && installState.status !== InstallStatus.DownloadEnding) {
-        const moduleIndicator = showProgress && download.moduleCount > 1 ? <span className=" text-gray-400">{download.moduleIndex + 1}/{download.moduleCount}</span> : null;
+        const moduleIndicator = showProgress && download.moduleCount > 1 ?
+            <span className=" text-gray-400">{download.moduleIndex + 1}/{download.moduleCount}</span> : null;
 
         moduleStateText = (
             <span className="flex items-center gap-x-3 mr-12 text-white text-4xl">
@@ -312,7 +319,7 @@ const DownloadProgressBanner: FC<DownloadProgressBannerProps> = ({ addon, instal
                 )}
             </StateContainer>
 
-            <ProgressBar className={progressBarBg} value={progressBarValue} />
+            <ProgressBar className={progressBarBg} value={progressBarValue}/>
         </div>
     );
 };

--- a/src/renderer/components/AddonSection/StateSection.tsx
+++ b/src/renderer/components/AddonSection/StateSection.tsx
@@ -42,11 +42,17 @@ export const StateSection: FC<StateSectionProps> = ({ publisher, addon }) => {
 
     return (
         <>
-            <BackgroundServiceBanner publisher={publisher} addon={addon}
-                installState={dependencyAddonInstallState ?? addonInstallState}/>
-            <DownloadProgressBanner addon={addon} installState={dependencyAddonInstallState ?? addonInstallState}
+            <BackgroundServiceBanner
+                publisher={publisher}
+                addon={addon}
+                installState={dependencyAddonInstallState ?? addonInstallState}
+            />
+            <DownloadProgressBanner
+                addon={addon}
+                installState={dependencyAddonInstallState ?? addonInstallState}
                 download={dependencyAddonDownload ?? addonDownload}
-                isDependency={isInstallingDependency}/>
+                isDependency={isInstallingDependency}
+            />
         </>
     );
 };
@@ -100,7 +106,7 @@ const BackgroundServiceBanner: FC<BackgroundServiceBannerProps> = ({ publisher, 
         const bgAccentColor = isRunning ? 'bg-utility-green' : 'bg-gray-500';
 
         const handleClickAutostart = () => showModal(
-            <AutostartDialog app={app} addon={addon} publisher={publisher} isPrompted={false}/>,
+            <AutostartDialog app={app} addon={addon} publisher={publisher} isPrompted={false} />,
         );
 
         const handleStartStop = async () => {
@@ -108,7 +114,7 @@ const BackgroundServiceBanner: FC<BackgroundServiceBannerProps> = ({ publisher, 
                 const md = `Are you sure you want to shut down **${addon.name}**?. All related functionality will no longer be available.`;
 
                 const doStop = await showModalAsync(
-                    <PromptModal title={"Are you sure?"} bodyText={md} confirmColor={ButtonType.Danger}/>,
+                    <PromptModal title={"Are you sure?"} bodyText={md} confirmColor={ButtonType.Danger} />,
                 );
 
                 if (doStop) {
@@ -125,9 +131,9 @@ const BackgroundServiceBanner: FC<BackgroundServiceBannerProps> = ({ publisher, 
                     <div className="flex gap-x-7 items-center">
                         {
                             isRunning ? (
-                                <Activity size={32} className={`text-utility-green fill-current animate-pulse`}/>
+                                <Activity size={32} className={`text-utility-green fill-current animate-pulse`} />
                             ) : (
-                                <Activity size={32} className={`text-gray-500 fill-current`}/>
+                                <Activity size={32} className={`text-gray-500 fill-current`} />
                             )
                         }
 
@@ -142,7 +148,7 @@ const BackgroundServiceBanner: FC<BackgroundServiceBannerProps> = ({ publisher, 
                             <span
                                 className="flex items-center gap-x-3.5 text-3xl text-quasi-white hover:text-cyan cursor-pointer"
                                 onClick={handleClickAutostart}>
-                                <Gear size={22}/>
+                                <Gear size={22} />
                                 Autostart...
                             </span>
                         )}
@@ -152,7 +158,7 @@ const BackgroundServiceBanner: FC<BackgroundServiceBannerProps> = ({ publisher, 
                     </div>
                 </StateContainer>
 
-                <ProgressBar className={bgAccentColor} value={100} animated={isRunning}/>
+                <ProgressBar className={bgAccentColor} value={100} animated={isRunning} />
             </div>
 
         );
@@ -181,14 +187,14 @@ const DownloadProgressBanner: FC<DownloadProgressBannerProps> = ({ addon, instal
     let progressBarValue;
     switch (installState.status) {
         case InstallStatus.DownloadPrep:
-            stateIcon = <Download size={40} className="text-white mr-6"/>;
+            stateIcon = <Download size={40} className="text-white mr-6" />;
             stateText = <SmallStateText>Preparing update</SmallStateText>;
             progressBarBg = 'bg-cyan';
             progressBarValue = 0;
             break;
         case InstallStatus.Downloading: {
             if (download.progress.interrupted) {
-                stateIcon = <WifiOff size={42} className="text-white mr-6"/>;
+                stateIcon = <WifiOff size={42} className="text-white mr-6" />;
                 stateText = <SmallStateText>{`Download interrupted`}</SmallStateText>;
                 progressBarBg = 'bg-utility-red';
             } else {
@@ -197,7 +203,7 @@ const DownloadProgressBanner: FC<DownloadProgressBannerProps> = ({ addon, instal
                         className="text-gray-300 ml-3">part {download.progress.splitPartIndex + 1}/{download.progress.splitPartCount}</span>
                     : null;
 
-                stateIcon = <Download size={40} className="text-white mr-6"/>;
+                stateIcon = <Download size={40} className="text-white mr-6" />;
                 stateText = <SmallStateText>{`Downloading`}{part}</SmallStateText>;
                 progressBarBg = 'bg-cyan';
             }
@@ -208,7 +214,7 @@ const DownloadProgressBanner: FC<DownloadProgressBannerProps> = ({ addon, instal
         }
         case InstallStatus.Decompressing:
         case InstallStatus.InstallingDependencyEnding:
-            stateIcon = <Download size={40} className="text-white mr-6"/>;
+            stateIcon = <Download size={40} className="text-white mr-6" />;
             stateText = <SmallStateText>Decompressing</SmallStateText>;
             progressBarBg = 'bg-cyan';
             progressBarValue = installState.percent;
@@ -225,7 +231,7 @@ const DownloadProgressBanner: FC<DownloadProgressBannerProps> = ({ addon, instal
             progressBarValue = 100;
             break;
         case InstallStatus.DownloadRetry:
-            stateIcon = <Stopwatch size={40} className="text-white mr-6"/>;
+            stateIcon = <Stopwatch size={40} className="text-white mr-6" />;
             stateText = <SmallStateText>Retrying {download?.module.toLowerCase()} module</SmallStateText>;
             progressBarBg = 'bg-utility-amber';
             progressBarValue = 100;
@@ -236,7 +242,7 @@ const DownloadProgressBanner: FC<DownloadProgressBannerProps> = ({ addon, instal
             progressBarValue = 100;
             break;
         case InstallStatus.DownloadCanceled:
-            stateIcon = <XOctagon size={40} className="text-white mr-6"/>;
+            stateIcon = <XOctagon size={40} className="text-white mr-6" />;
             stateText = <SmallStateText>Download canceled</SmallStateText>;
             progressBarBg = 'bg-utility-amber';
             progressBarValue = 100;
@@ -319,7 +325,7 @@ const DownloadProgressBanner: FC<DownloadProgressBannerProps> = ({ addon, instal
                 )}
             </StateContainer>
 
-            <ProgressBar className={progressBarBg} value={progressBarValue}/>
+            <ProgressBar className={progressBarBg} value={progressBarValue} />
         </div>
     );
 };

--- a/src/renderer/components/AddonSection/index.tsx
+++ b/src/renderer/components/AddonSection/index.tsx
@@ -139,7 +139,7 @@ export const AddonSection = (): JSX.Element => {
 
         try {
             const manifest = getCurrentInstall(
-                Directories.inCommunity(selectedAddon.targetDirectory),
+                Directories.inInstallLocation(selectedAddon.targetDirectory),
             );
             console.log("Currently installed", manifest);
 
@@ -301,7 +301,7 @@ export const AddonSection = (): JSX.Element => {
     };
 
     const handleInstall = async () => {
-        if (settings.has("mainSettings.msfsPackagePath")) {
+        if (settings.has("mainSettings.installPath")) {
             await InstallManager.installAddon(selectedAddon, publisherData, showModalAsync);
         } else {
             await setupInstallPath();

--- a/src/renderer/components/ErrorModal/index.tsx
+++ b/src/renderer/components/ErrorModal/index.tsx
@@ -5,8 +5,8 @@ import { Directories } from "renderer/utils/Directories";
 import * as fs from "fs";
 
 export const ErrorModal = (): JSX.Element => {
-    const [communityError, setCommunityError] = useState<boolean>(!fs.existsSync(Directories.community()) || Directories.community() === 'C:\\');
-    const [linuxError, setLinuxError] = useState<boolean>(Directories.community() === 'linux');
+    const [communityError, setCommunityError] = useState<boolean>(!fs.existsSync(Directories.installLocation()) || Directories.installLocation() === 'C:\\');
+    const [linuxError, setLinuxError] = useState<boolean>(Directories.installLocation() === 'linux');
 
     const handleClose = () => {
         setCommunityError(false);
@@ -33,11 +33,11 @@ export const ErrorModal = (): JSX.Element => {
                 </>
             );
         }
-        if (communityError && (Directories.community() !== 'linux')) {
+        if (communityError && (Directories.installLocation() !== 'linux')) {
             return (
                 <>
                     <span className="w-3/5 text-center text-2xl">Your Community folder is set to</span>
-                    <pre className="w-3/5 bg-gray-700 text-2xl text-center font-mono px-6 py-2.5 mb-0 rounded-lg">{Directories.community()}</pre>
+                    <pre className="w-3/5 bg-gray-700 text-2xl text-center font-mono px-6 py-2.5 mb-0 rounded-lg">{Directories.installLocation()}</pre>
                     <span className="w-3/5 text-center text-2xl">but we couldn't find it there. Please set the correct location before we can continue.</span>
                     <button className="bg-navy-lightest hover:bg-navy-lighter px-5 py-2 text-lg font-semibold rounded-lg" onClick={handleSelectPath}>Select</button>
                 </>

--- a/src/renderer/components/LocalApiConfigEditUI/index.tsx
+++ b/src/renderer/components/LocalApiConfigEditUI/index.tsx
@@ -37,7 +37,7 @@ const localApiDefaultConfiguration: LocalApiConfiguration = {
 
 class LocalApiConfigurationHandler {
     private static get simbridgeDirectory(): string {
-        return path.join(Directories.inCommunity(SIMBRIDGE_DIRECTORY));
+        return path.join(Directories.inInstallLocation(SIMBRIDGE_DIRECTORY));
     }
 
     private static get simbridgeConfigPath(): string {

--- a/src/renderer/components/Modal/IncompatibleAddonDialog.tsx
+++ b/src/renderer/components/Modal/IncompatibleAddonDialog.tsx
@@ -8,39 +8,26 @@ export interface IncompatibleAddonDialogBodyProps {
 
 export const IncompatibleAddonDialogBody: FC<IncompatibleAddonDialogBodyProps> = ({ addon, incompatibleAddons }) => (
     <>
-        The following addons are incompatible with "{addon.name}":
-        <p/>
-        <ul>
-            {incompatibleAddons.map((a) => (
-                <li>- {a.title} ({a.folder})</li>
-            ))}
-        </ul>
-        <p/>
-        It is recommended to uninstall these addons before installing "{addon.name}".
-        <p/>
-        <span className="text-4xl">Continue installing "{addon.name}"?</span>
-        {/*<p>*/}
-        {/*    <b>{dependencyAddon.name}</b>*/}
-        {/*    {' '}*/}
-        {/*    by*/}
-        {/*    {' '}*/}
-        {/*    <b>{dependencyPublisher.name}</b>*/}
-        {/*    {' '}*/}
-        {/*    needs to be installed to use the full functionality of*/}
-        {/*    {' '}*/}
-        {/*    <b>{addon.name}</b>*/}
-        {/*    .*/}
-        {/*</p>*/}
-
-        {/*<div className="flex items-center gap-x-7 bg-navy px-7 py-6 rounded-md my-6">*/}
-        {/*    <Box size={36} />*/}
-
-        {/*    <div className="flex flex-col gap-y-2">*/}
-        {/*        <span className="text-3xl font-medium">{dependencyPublisher.name}</span>*/}
-        {/*        <span className="text-4xl font-semibold">{dependencyAddon.name}</span>*/}
-        {/*    </div>*/}
-        {/*</div>*/}
-
-        {/*<p>{dependency.modalText}</p>*/}
+        <p>
+            The following addons are incompatible with "{addon.name}":
+        </p>
+        <p className="h-80 overflow-y-scroll">
+            <ul className="pl-2">
+                {incompatibleAddons.map((a) => (
+                    <div className="flex items-center gap-x-7 bg-navy px-7 py-6 rounded-md my-6">
+                        <div className="flex flex-col gap-y-2">
+                            <span className="text-2xl font-bold">{a.title}</span>
+                            {' '}
+                            <span>{a.folder}</span>
+                            {' '}
+                            <span className="text-l">{a.description}</span>
+                        </div>
+                    </div>
+                ))}
+            </ul>
+        </p>
+        <p>
+            <span className="text-4xl">Continue installing "{addon.name}"?</span>
+        </p>
     </>
 );

--- a/src/renderer/components/Modal/IncompatibleAddonDialog.tsx
+++ b/src/renderer/components/Modal/IncompatibleAddonDialog.tsx
@@ -1,0 +1,46 @@
+import React, { FC } from "react";
+import { Addon, AddonIncompatibleAddon } from "renderer/utils/InstallerConfiguration";
+
+export interface IncompatibleAddonDialogBodyProps {
+    addon: Addon,
+    incompatibleAddons: AddonIncompatibleAddon[],
+}
+
+export const IncompatibleAddonDialogBody: FC<IncompatibleAddonDialogBodyProps> = ({ addon, incompatibleAddons }) => (
+    <>
+        The following addons are incompatible with "{addon.name}":
+        <p/>
+        <ul>
+            {incompatibleAddons.map((a) => (
+                <li>- {a.title} ({a.folder})</li>
+            ))}
+        </ul>
+        <p/>
+        It is recommended to uninstall these addons before installing "{addon.name}".
+        <p/>
+        <span className="text-4xl">Continue installing "{addon.name}"?</span>
+        {/*<p>*/}
+        {/*    <b>{dependencyAddon.name}</b>*/}
+        {/*    {' '}*/}
+        {/*    by*/}
+        {/*    {' '}*/}
+        {/*    <b>{dependencyPublisher.name}</b>*/}
+        {/*    {' '}*/}
+        {/*    needs to be installed to use the full functionality of*/}
+        {/*    {' '}*/}
+        {/*    <b>{addon.name}</b>*/}
+        {/*    .*/}
+        {/*</p>*/}
+
+        {/*<div className="flex items-center gap-x-7 bg-navy px-7 py-6 rounded-md my-6">*/}
+        {/*    <Box size={36} />*/}
+
+        {/*    <div className="flex flex-col gap-y-2">*/}
+        {/*        <span className="text-3xl font-medium">{dependencyPublisher.name}</span>*/}
+        {/*        <span className="text-4xl font-semibold">{dependencyAddon.name}</span>*/}
+        {/*    </div>*/}
+        {/*</div>*/}
+
+        {/*<p>{dependency.modalText}</p>*/}
+    </>
+);

--- a/src/renderer/components/Modal/index.css
+++ b/src/renderer/components/Modal/index.css
@@ -31,3 +31,7 @@
 .markdown-body-modal a:hover {
     text-decoration: underline;
 }
+
+.h-80 {
+    height: 20rem;
+}

--- a/src/renderer/components/SettingsSection/Download.tsx
+++ b/src/renderer/components/SettingsSection/Download.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { setupInstallPath, setupTempLocation } from 'renderer/actions/install-path.utils';
+import { setupMsfsCommunityPath, setupInstallPath, setupTempLocation } from 'renderer/actions/install-path.utils';
 import settings, { useSetting } from "common/settings";
 import { Toggle } from '../Toggle';
 
@@ -15,6 +15,22 @@ interface SettingItemProps<T> {
     value: T;
     setValue: (value: T) => void;
 }
+
+const MsfsCommunityPathSettingItem = ({ value, setValue }: SettingItemProps<string>): JSX.Element => {
+    const handleClick = async () => {
+        const path = await setupMsfsCommunityPath();
+
+        if (path) {
+            setValue(path);
+        }
+    };
+
+    return (
+        <SettingsItem name="MSFS Community Directory">
+            <div className="text-white hover:text-gray-400 cursor-pointer underline transition duration-200" onClick={handleClick}>{value}</div>
+        </SettingsItem>
+    );
+};
 
 const InstallPathSettingItem = ({ value, setValue }: SettingItemProps<string>): JSX.Element => {
     const handleClick = async () => {
@@ -53,7 +69,7 @@ const SeparateTempLocationSettingItem = ({ value, setValue }: SettingItemProps<b
         const newState = !value;
         setValue(newState);
         settings.set('mainSettings.separateTempLocation', newState);
-        settings.set('mainSettings.tempLocation', settings.get('mainSettings.msfsPackagePath'));
+        settings.set('mainSettings.tempLocation', settings.get('mainSettings.installPath'));
     };
 
     return (
@@ -101,7 +117,8 @@ const UseCdnSettingItem = ({ value, setValue }: SettingItemProps<boolean>) => {
 };
 
 const index = (): JSX.Element => {
-    const [installPath, setInstallPath] = useSetting<string>('mainSettings.msfsPackagePath');
+    const [communityPath, setCommunityPath] = useSetting<string>('mainSettings.msfsCommunityPath');
+    const [installPath, setInstallPath] = useSetting<string>('mainSettings.installPath');
     const [tempLocation, setTempLocation] = useSetting<string>('mainSettings.tempLocation');
     const [separateTempLocation, setSeparateTempLocation] = useSetting<boolean>('mainSettings.separateTempLocation');
     const [disableVersionWarning, setDisableVersionWarning] = useSetting<boolean>('mainSettings.disableExperimentalWarning');
@@ -112,6 +129,7 @@ const index = (): JSX.Element => {
             <div className="flex flex-col">
                 <h2 className="text-white">Download Settings</h2>
                 <div className="flex flex-col divide-y divide-gray-600">
+                    <MsfsCommunityPathSettingItem value={communityPath} setValue={setCommunityPath} />
                     <InstallPathSettingItem value={installPath} setValue={setInstallPath} />
                     <SeparateTempLocationSettingItem value={separateTempLocation} setValue={setSeparateTempLocation} />
                     {separateTempLocation &&

--- a/src/renderer/data.ts
+++ b/src/renderer/data.ts
@@ -150,20 +150,19 @@ export const defaultConfiguration: Configuration = {
                     ],
                     incompatibleAddons: [
                         {
-                            title: 'FSUIPC7 WASM Event Module',
-                            creator: "John L. Dowson",
-                            package_version: "",
-                            description: "This add-on is incompatible with the A32NX. Please remove them before installing the A32NX.",
+                            title: 'LVFR A321neo FBW A32NX Compatibility Mod',
+                            creator: 'TJC.Aviation',
+                            description: "REMOVE this add-on before installing and using the A32NX. This add-on overrides A32NX components and renders the A32NX unusable.",
                         },
                         {
-                            title: 'A32NX Liveries',
-                            creator: "CdrMaverick",
-                            package_version: "1.0.5",
-                            description: "This add-on is incompatible with the A32NX. Please remove them before installing the A32NX.",
+                            title: 'Toolbar Pushback',
+                            creator: "AmbitiousPilots",
+                            description: "This add-on sometimes causes performance issues and also prevents the A32NX from taxiing. Consider removing it in case of issues.",
                         },
                         {
-                            title: 'Salty 747-8',
-                            description: "This add-on is incompatible with the A32NX. Please remove them before installing the A32NX.",
+                            title: '[MOD] Mugz FBW A32NX Dev',
+                            creator: "Mugz",
+                            description: "REMOVE this add-on before installing and using the A32NX. This add-on overrides A32NX components and renders the A32NX unusable.",
                         },
                     ],
                     myInstallPage: {

--- a/src/renderer/data.ts
+++ b/src/renderer/data.ts
@@ -148,28 +148,7 @@ export const defaultConfiguration: Configuration = {
                             modalText: 'SimBridge allows the A32NX to expose remote tools like the Web MCDU, as well as use the external terrain database.',
                         },
                     ],
-                    incompatibleAddons: [
-                        {
-                            title: 'LVFR A321neo FBW A32NX Compatibility Mod',
-                            creator: 'TJC.Aviation',
-                            description: "REMOVE this add-on before installing and using the A32NX. This add-on overrides A32NX components and renders the A32NX unusable.",
-                        },
-                        {
-                            title: '[MOD] Mugz FBW A32NX Dev',
-                            creator: "Mugz",
-                            description: "REMOVE this add-on before installing and using the A32NX. This add-on overrides A32NX components and renders the A32NX unusable.",
-                        },
-                        {
-                            title: '[MOD] Mugz FBW A32NX Stable',
-                            creator: "Mugz",
-                            description: "REMOVE this add-on before installing and using the A32NX. This add-on overrides A32NX components and renders the A32NX unusable.",
-                        },
-                        {
-                            title: 'Toolbar Pushback',
-                            creator: "AmbitiousPilots",
-                            description: "This add-on sometimes causes performance issues and also prevents the A32NX from taxiing. Consider removing it in case of issues.",
-                        },
-                    ],
+                    incompatibleAddons: [],
                     myInstallPage: {
                         links: [
                             {

--- a/src/renderer/data.ts
+++ b/src/renderer/data.ts
@@ -154,6 +154,16 @@ export const defaultConfiguration: Configuration = {
                             creator: "John L. Dowson",
                             package_version: "",
                             description: "This add-on is incompatible with the A32NX. Please remove them before installing the A32NX.",
+                        },
+                        {
+                            title: 'A32NX Liveries',
+                            creator: "CdrMaverick",
+                            package_version: "1.0.5",
+                            description: "This add-on is incompatible with the A32NX. Please remove them before installing the A32NX.",
+                        },
+                        {
+                            title: 'Salty 747-8',
+                            description: "This add-on is incompatible with the A32NX. Please remove them before installing the A32NX.",
                         }
                     ],
                     myInstallPage: {

--- a/src/renderer/data.ts
+++ b/src/renderer/data.ts
@@ -148,6 +148,14 @@ export const defaultConfiguration: Configuration = {
                             modalText: 'SimBridge allows the A32NX to expose remote tools like the Web MCDU, as well as use the external terrain database.',
                         },
                     ],
+                    incompatibleAddons: [
+                        {
+                            title: 'FSUIPC7 WASM Event Module',
+                            creator: "John L. Dowson",
+                            package_version: "",
+                            description: "This add-on is incompatible with the A32NX. Please remove them before installing the A32NX.",
+                        }
+                    ],
                     myInstallPage: {
                         links: [
                             {

--- a/src/renderer/data.ts
+++ b/src/renderer/data.ts
@@ -164,7 +164,7 @@ export const defaultConfiguration: Configuration = {
                         {
                             title: 'Salty 747-8',
                             description: "This add-on is incompatible with the A32NX. Please remove them before installing the A32NX.",
-                        }
+                        },
                     ],
                     myInstallPage: {
                         links: [

--- a/src/renderer/data.ts
+++ b/src/renderer/data.ts
@@ -155,14 +155,19 @@ export const defaultConfiguration: Configuration = {
                             description: "REMOVE this add-on before installing and using the A32NX. This add-on overrides A32NX components and renders the A32NX unusable.",
                         },
                         {
-                            title: 'Toolbar Pushback',
-                            creator: "AmbitiousPilots",
-                            description: "This add-on sometimes causes performance issues and also prevents the A32NX from taxiing. Consider removing it in case of issues.",
-                        },
-                        {
                             title: '[MOD] Mugz FBW A32NX Dev',
                             creator: "Mugz",
                             description: "REMOVE this add-on before installing and using the A32NX. This add-on overrides A32NX components and renders the A32NX unusable.",
+                        },
+                        {
+                            title: '[MOD] Mugz FBW A32NX Stable',
+                            creator: "Mugz",
+                            description: "REMOVE this add-on before installing and using the A32NX. This add-on overrides A32NX components and renders the A32NX unusable.",
+                        },
+                        {
+                            title: 'Toolbar Pushback',
+                            creator: "AmbitiousPilots",
+                            description: "This add-on sometimes causes performance issues and also prevents the A32NX from taxiing. Consider removing it in case of issues.",
                         },
                     ],
                     myInstallPage: {

--- a/src/renderer/utils/AddonData.ts
+++ b/src/renderer/utils/AddonData.ts
@@ -79,7 +79,7 @@ export class AddonData {
         } else {
             console.log (addon.key, 'is installed');
             try {
-                const manifest = getCurrentInstall(Directories.inCommunity(addon.targetDirectory));
+                const manifest = getCurrentInstall(Directories.inInstallLocation(addon.targetDirectory));
                 console.log('Currently installed', manifest);
 
                 let track = addon.tracks.find(track => track.url.includes(manifest.source));
@@ -114,7 +114,7 @@ export class AddonData {
 
         console.log('Checking install status');
 
-        const installDir = Directories.inCommunity(addon.targetDirectory);
+        const installDir = Directories.inInstallLocation(addon.targetDirectory);
 
         if (!fs.existsSync(installDir)) {
             console.log ('no existing install dir for', addon.key);
@@ -157,7 +157,7 @@ export class AddonData {
 
         const dispatch = store.dispatch;
 
-        const installDir = Directories.inCommunity(addon.targetDirectory);
+        const installDir = Directories.inInstallLocation(addon.targetDirectory);
 
         const state = store.getState();
 

--- a/src/renderer/utils/BackgroundServices.ts
+++ b/src/renderer/utils/BackgroundServices.ts
@@ -74,7 +74,7 @@ export class BackgroundServices {
             throw new Error('Executable path much match /^[a-zA-Z\\d_-]+$/.');
         }
 
-        const exePath = path.join(Directories.inCommunity(addon.targetDirectory), backgroundService.executableFileBasename);
+        const exePath = path.join(Directories.inInstallLocation(addon.targetDirectory), backgroundService.executableFileBasename);
         const commandLineArgs = backgroundService.commandLineArgs
             ? ` ${backgroundService.commandLineArgs.join(' ')}`
             : '';
@@ -113,7 +113,7 @@ export class BackgroundServices {
             throw new Error('Executable path much match /^[a-zA-Z\\d_-]+$/.');
         }
 
-        const exePath = path.normalize(path.join(Directories.inCommunity(addon.targetDirectory), `${backgroundService.executableFileBasename}.exe`));
+        const exePath = path.normalize(path.join(Directories.inInstallLocation(addon.targetDirectory), `${backgroundService.executableFileBasename}.exe`));
 
         await shell.openPath(exePath);
 

--- a/src/renderer/utils/Directories.ts
+++ b/src/renderer/utils/Directories.ts
@@ -13,22 +13,34 @@ export class Directories {
         return path.normalize(suffix).replace(/^(\.\.(\/|\\|$))+/, '');
     }
 
-    static community(): string {
-        return settings.get('mainSettings.msfsPackagePath') as string;
+    static communityLocation(): string {
+        return settings.get('mainSettings.msfsCommunityPath') as string;
     }
 
-    static inCommunity(targetDir: string): string {
-        return path.join(Directories.community(), this.sanitize(targetDir));
+    static inCommunityLocation(targetDir: string): string {
+        return path.join(Directories.communityLocation(), this.sanitize(targetDir));
     }
 
     static inCommunityPackage(addon: Addon, targetDir: string): string {
-        const baseDir = this.inCommunity(this.sanitize(addon.targetDirectory));
+        const baseDir = this.inCommunityLocation(this.sanitize(addon.targetDirectory));
+        return path.join(baseDir, this.sanitize(targetDir));
+    }
 
+    static installLocation(): string {
+        return settings.get('mainSettings.installPath') as string;
+    }
+
+    static inInstallLocation(targetDir: string): string {
+        return path.join(Directories.installLocation(), this.sanitize(targetDir));
+    }
+
+    static inInstallPackage(addon: Addon, targetDir: string): string {
+        const baseDir = this.inInstallLocation(this.sanitize(addon.targetDirectory));
         return path.join(baseDir, this.sanitize(targetDir));
     }
 
     static tempLocation(): string {
-        return settings.get('mainSettings.separateTempLocation') ? settings.get('mainSettings.tempLocation') as string : settings.get('mainSettings.msfsPackagePath') as string;
+        return settings.get('mainSettings.separateTempLocation') ? settings.get('mainSettings.tempLocation') as string : settings.get('mainSettings.installPath') as string;
     }
 
     static inTempLocation(targetDir: string): string {
@@ -92,7 +104,7 @@ export class Directories {
 
     static removeAlternativesForAddon(addon: Addon): void {
         addon.alternativeNames?.forEach(altName => {
-            const altDir = Directories.inCommunity(altName);
+            const altDir = Directories.inInstallLocation(altName);
 
             if (fs.existsSync(altDir)) {
                 console.log('Removing alternative', altDir);
@@ -102,7 +114,7 @@ export class Directories {
     }
 
     static removeTargetForAddon(addon: Addon): void {
-        const dir = Directories.inCommunity(addon.targetDirectory);
+        const dir = Directories.inInstallLocation(addon.targetDirectory);
 
         if (fs.existsSync(dir)) {
             console.log('Removing', dir);
@@ -111,13 +123,13 @@ export class Directories {
     }
 
     static isFragmenterInstall(target: string | Addon): boolean {
-        const targetDir = typeof target === 'string' ? target : Directories.inCommunity(target.targetDirectory);
+        const targetDir = typeof target === 'string' ? target : Directories.inInstallLocation(target.targetDirectory);
 
         return fs.existsSync(path.join(targetDir, 'install.json'));
     }
 
     static isGitInstall(target: string | Addon): boolean {
-        const targetDir = typeof target === 'string' ? target : Directories.inCommunity(target.targetDirectory);
+        const targetDir = typeof target === 'string' ? target : Directories.inInstallLocation(target.targetDirectory);
 
         try {
             const symlinkPath = fs.readlinkSync(targetDir);

--- a/src/renderer/utils/IncompatibleAddOnsCheck.ts
+++ b/src/renderer/utils/IncompatibleAddOnsCheck.ts
@@ -43,7 +43,7 @@ export class IncompatibleAddOnsCheck {
 
                             if (titleMatches && creatorMatches && packageVersionTargeted) {
                                 // Also write this to the log as this info might be useful for support.
-                                console.log("Incompatible Add-On found: %s: %s", manifest.title, item.description);
+                                console.log(`Incompatible Add-On found: ${manifest.title}: ${item.description}`);
 
                                 incompatibleAddons.push({
                                     title: item.title,

--- a/src/renderer/utils/IncompatibleAddOnsCheck.ts
+++ b/src/renderer/utils/IncompatibleAddOnsCheck.ts
@@ -1,0 +1,62 @@
+import { Directories } from "renderer/utils/Directories";
+import { Addon, AddonIncompatibleAddon } from "renderer/utils/InstallerConfiguration";
+import fs from "fs-extra";
+import path from "path";
+import semverSatisfies from 'semver/functions/satisfies';
+
+export class IncompatibleAddOnsCheck {
+
+    /**
+     * Find incompatible add-ons
+     * This iterates through the first level of folders of the  MSFS Community folder looking for the manifest.json
+     * file. It compares the manifest.json file content with the configured incompatible add-ons (data.ts) and if it
+     * finds one or more matches, it will issue a warning.
+     */
+    static async checkIncompatibleAddOns(addon: Addon): Promise<AddonIncompatibleAddon[]> {
+        console.log('Searching incompatible add-ons');
+        const incompatibleAddons: AddonIncompatibleAddon[] = [];
+        const manifestFileName = 'manifest.json';
+        const comDir = Directories.communityLocation();
+        try {
+            const addonFolders = fs.readdirSync(comDir);
+            for (const entry of addonFolders) {
+                const filePath = path.join(comDir, entry);
+                const stat = fs.statSync(filePath);
+                if (stat.isDirectory()) {
+                    const dirEntries = fs.readdirSync(filePath);
+                    if (dirEntries.includes(manifestFileName)) {
+                        const manifest = JSON.parse(fs.readFileSync(path.join(filePath, manifestFileName), 'utf8'));
+                        for (const item of addon.incompatibleAddons) {
+                            // This checks the configuration item properties (if set) against the manifest.json file
+                            // entry property values. If all properties match, the add-on is considered incompatible.
+                            // packageVersion syntax follows: https://www.npmjs.com/package/semver
+                            // Future improvement would be to allow for regular expressions in the configuration item.
+                            if ((!item.title || manifest.title === item.title) &&
+                                (!item.creator || manifest.creator === item.creator) &&
+                                (!item.packageVersion || semverSatisfies(manifest.package_version, item.packageVersion))
+                            ) {
+                                // Also write this to the log as this info might be useful for support.
+                                console.log("Incompatible Add-On found: %s: %s", manifest.title, item.description);
+                                incompatibleAddons.push({
+                                    title: item.title,
+                                    creator: item.creator,
+                                    packageVersion: item.packageVersion,
+                                    folder: entry,
+                                    description: item.description,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (e) {
+            console.error("Error searching incompatible add-ons in %s: %s", comDir, e);
+        }
+        if (incompatibleAddons.length > 0) {
+            console.log('Incompatible add-ons found');
+        } else {
+            console.log('No incompatible add-ons found');
+        }
+        return incompatibleAddons;
+    }
+}

--- a/src/renderer/utils/InstallManager.tsx
+++ b/src/renderer/utils/InstallManager.tsx
@@ -322,11 +322,6 @@ export class InstallManager {
             }
         }
 
-        // DEBUG
-        startResetStateTimer();
-        return InstallResult.Cancelled;
-        // DEBUG
-
         const destDir = Directories.inInstallLocation(addon.targetDirectory);
         const tempDir = Directories.temp();
 

--- a/src/renderer/utils/InstallManager.tsx
+++ b/src/renderer/utils/InstallManager.tsx
@@ -74,7 +74,7 @@ export class InstallManager {
 
         console.log("Checking install status");
 
-        const installDir = Directories.inCommunity(addon.targetDirectory);
+        const installDir = Directories.inInstallLocation(addon.targetDirectory);
 
         if (!fs.existsSync(installDir)) {
             return { status: InstallStatus.NotInstalled };
@@ -264,6 +264,7 @@ export class InstallManager {
 
         // Find incompatible add-ons
         for (const incompatibility of addon.incompatibleAddons ?? []) {
+            console.log('Community folder: ', Directories.communityLocation(), 'Install folder: ', Directories.installLocation());
             console.log('Checking for incompatible add-ons',
                 incompatibility.title,
                 incompatibility.creator,
@@ -271,7 +272,7 @@ export class InstallManager {
                 incompatibility.description);
         }
 
-        const destDir = Directories.inCommunity(addon.targetDirectory);
+        const destDir = Directories.inInstallLocation(addon.targetDirectory);
         const tempDir = Directories.temp();
 
         const fragmenterUpdateChecker = new FragmenterUpdateChecker();
@@ -312,7 +313,7 @@ export class InstallManager {
 
         store.dispatch(registerNewDownload({ id: addon.key, module: '', moduleCount, abortControllerID: abortControllerID }));
 
-        if (tempDir === Directories.community()) {
+        if (tempDir === Directories.installLocation()) {
             console.error('Community directory equals temp directory');
             this.notifyDownload(addon, false);
             return InstallResult.Failure;
@@ -612,7 +613,7 @@ export class InstallManager {
             await BackgroundServices.setAutoStartEnabled(addon, publisher, false);
         }
 
-        const installDir = Directories.inCommunity(addon.targetDirectory);
+        const installDir = Directories.inInstallLocation(addon.targetDirectory);
 
         await ipcRenderer.invoke(
             channels.installManager.uninstall,

--- a/src/renderer/utils/InstallManager.tsx
+++ b/src/renderer/utils/InstallManager.tsx
@@ -262,6 +262,15 @@ export class InstallManager {
             }
         }
 
+        // Find incompatible add-ons
+        for (const incompatibility of addon.incompatibleAddons ?? []) {
+            console.log('Checking for incompatible add-ons',
+                incompatibility.title,
+                incompatibility.creator,
+                incompatibility.package_version,
+                incompatibility.description);
+        }
+
         const destDir = Directories.inCommunity(addon.targetDirectory);
         const tempDir = Directories.temp();
 

--- a/src/renderer/utils/InstallManager.tsx
+++ b/src/renderer/utils/InstallManager.tsx
@@ -180,7 +180,7 @@ export class InstallManager {
 
         if (runningExternalApps.length > 0) {
             const doInstall = await showModal(
-                <CannotInstallDialog addon={addon} publisher={publisher}/>,
+                <CannotInstallDialog addon={addon} publisher={publisher} />,
             );
 
             if (!doInstall) {
@@ -307,7 +307,7 @@ export class InstallManager {
                 <PromptModal
                     title="Incompatible Add-ons Found!"
                     bodyText={
-                        <IncompatibleAddonDialogBody addon={addon} incompatibleAddons={incompatibleAddons}/>
+                        <IncompatibleAddonDialogBody addon={addon} incompatibleAddons={incompatibleAddons} />
                     }
                     cancelText="No"
                     confirmText="Yes"
@@ -341,7 +341,7 @@ export class InstallManager {
         if (Number.isFinite(requiredDiskSpace) && Number.isFinite(availableDiskSpace) && (!dontAsk || requiredDiskSpace >= availableDiskSpace)) {
             const continueInstall = await showModal(<InstallSizeDialog updateInfo={updateInfo}
                 availableDiskSpace={availableDiskSpace}
-                dontShowAgainSettingName={diskSpaceModalSettingString}/>);
+                dontShowAgainSettingName={diskSpaceModalSettingString} />);
 
             if (!continueInstall) {
                 startResetStateTimer();
@@ -591,7 +591,7 @@ export class InstallManager {
 
                 if (!isAutoStartEnabled && !doNotAskAgain) {
                     await showModal(
-                        <AutostartDialog app={app} addon={addon} publisher={publisher} isPrompted={true}/>,
+                        <AutostartDialog app={app} addon={addon} publisher={publisher} isPrompted={true} />,
                     );
                 }
             }
@@ -611,7 +611,7 @@ export class InstallManager {
                 startResetStateTimer();
 
                 Sentry.captureException(e);
-                await showModal(<ErrorDialog error={e}/>);
+                await showModal(<ErrorDialog error={e} />);
 
                 return InstallResult.Failure;
             }

--- a/src/renderer/utils/InstallManager.tsx
+++ b/src/renderer/utils/InstallManager.tsx
@@ -281,11 +281,16 @@ export class InstallManager {
                     if (dirEntries.includes(manifestFileName)) {
                         const manifest = JSON.parse(fs.readFileSync(path.join(filePath, manifestFileName), 'utf8'));
                         for (const item of addon.incompatibleAddons) {
+                            // this checks the configuration item properties (if set) against the manifest.json file
+                            // entry property values. If all properties match, the add-on is considered incompatible.
+                            // Future improvement would be to allow for regular expressions in the configuration item and
+                            // a more sophisticated version comparison.
                             if ((!item.title || manifest.title === item.title) &&
                                 (!item.creator || manifest.creator === item.creator) &&
                                 (!item.packageVersion || manifest.package_version === item.packageVersion)
                             ) {
-                                console.log("!!! %s: %s", manifest.title, item.description);
+                                // Also write this to the log as this info might be useful for support.
+                                console.log("Incompatible Add-On found: %s: %s", manifest.title, item.description);
                                 incompatibleAddons.push({
                                     title: item.title,
                                     creator: item.creator,

--- a/src/renderer/utils/InstallManager.tsx
+++ b/src/renderer/utils/InstallManager.tsx
@@ -40,6 +40,8 @@ import { ErrorDialog } from "renderer/components/Modal/ErrorDialog";
 import { InstallSizeDialog } from "renderer/components/Modal/InstallSizeDialog";
 import checkDiskSpace from "check-disk-space";
 
+const semverSatisfies = require('semver/functions/satisfies');
+
 type FragmenterEventArguments<K extends keyof FragmenterInstallerEvents | keyof FragmenterContextEvents> = Parameters<(FragmenterInstallerEvents & FragmenterContextEvents)[K]>
 
 export enum InstallResult {
@@ -283,11 +285,11 @@ export class InstallManager {
                         for (const item of addon.incompatibleAddons) {
                             // this checks the configuration item properties (if set) against the manifest.json file
                             // entry property values. If all properties match, the add-on is considered incompatible.
-                            // Future improvement would be to allow for regular expressions in the configuration item and
-                            // a more sophisticated version comparison.
+                            // packageVersion syntax follows: https://www.npmjs.com/package/semver
+                            // Future improvement would be to allow for regular expressions in the configuration item
                             if ((!item.title || manifest.title === item.title) &&
                                 (!item.creator || manifest.creator === item.creator) &&
-                                (!item.packageVersion || manifest.package_version === item.packageVersion)
+                                (!item.packageVersion || semverSatisfies(manifest.package_version, item.packageVersion))
                             ) {
                                 // Also write this to the log as this info might be useful for support.
                                 console.log("Incompatible Add-On found: %s: %s", manifest.title, item.description);

--- a/src/renderer/utils/InstallManager.tsx
+++ b/src/renderer/utils/InstallManager.tsx
@@ -283,13 +283,13 @@ export class InstallManager {
                         for (const item of addon.incompatibleAddons) {
                             if ((!item.title || manifest.title === item.title) &&
                                 (!item.creator || manifest.creator === item.creator) &&
-                                (!item.package_version || manifest.package_version === item.package_version)
+                                (!item.packageVersion || manifest.package_version === item.packageVersion)
                             ) {
                                 console.log("!!! %s: %s", manifest.title, item.description);
                                 incompatibleAddons.push({
                                     title: item.title,
                                     creator: item.creator,
-                                    package_version: item.package_version,
+                                    packageVersion: item.packageVersion,
                                     folder: entry,
                                     description: item.description,
                                 });

--- a/src/renderer/utils/InstallManager.tsx
+++ b/src/renderer/utils/InstallManager.tsx
@@ -266,38 +266,36 @@ export class InstallManager {
         // Find incompatible add-ons
         // This iterates through the first level of folders of the  MSFS Community folder looking for the manifest.json
         // file. It compares the manifest.json file content with the configured incompatible add-ons (data.ts) and if it
-        // finds a match, it will issue a warning.
+        // finds one or more matches, it will issue a warning.
         console.log('Searching incompatible add-ons');
+        const manifestFileName = 'manifest.json';
         const comDir = Directories.communityLocation();
         const incompatibleAddons: AddonIncompatibleAddon[] = [];
         try {
-            const dirs = fs.readdirSync(comDir);
-            for (const entry of dirs) {
+            const addonFolders = fs.readdirSync(comDir);
+            for (const entry of addonFolders) {
                 const filePath = path.join(comDir, entry);
                 const stat = fs.statSync(filePath);
                 if (stat.isDirectory()) {
                     const dirEntries = fs.readdirSync(filePath);
-                    dirEntries.forEach((f) => {
-                        if (f === 'manifest.json') {
-                            const data = fs.readFileSync(path.join(filePath, f), 'utf8');
-                            const manifest = JSON.parse(data);
-                            for (const item of addon.incompatibleAddons) {
-                                if ((!item.title || manifest.title === item.title) &&
-                                    (!item.creator || manifest.creator === item.creator) &&
-                                    (!item.package_version || manifest.package_version === item.package_version)
-                                ) {
-                                    console.log("!!! %s: %s", manifest.title, item.description);
-                                    incompatibleAddons.push({
-                                        title: item.title,
-                                        creator: item.creator,
-                                        package_version: item.package_version,
-                                        folder: entry,
-                                        description: item.description,
-                                    });
-                                }
+                    if (dirEntries.includes(manifestFileName)) {
+                        const manifest = JSON.parse(fs.readFileSync(path.join(filePath, manifestFileName), 'utf8'));
+                        for (const item of addon.incompatibleAddons) {
+                            if ((!item.title || manifest.title === item.title) &&
+                                (!item.creator || manifest.creator === item.creator) &&
+                                (!item.package_version || manifest.package_version === item.package_version)
+                            ) {
+                                console.log("!!! %s: %s", manifest.title, item.description);
+                                incompatibleAddons.push({
+                                    title: item.title,
+                                    creator: item.creator,
+                                    package_version: item.package_version,
+                                    folder: entry,
+                                    description: item.description,
+                                });
                             }
                         }
-                    });
+                    }
                 }
             }
         } catch (e) {

--- a/src/renderer/utils/InstallerConfiguration.ts
+++ b/src/renderer/utils/InstallerConfiguration.ts
@@ -164,7 +164,7 @@ export interface AddonIncompatibleAddon {
      */
     title?: string,
     creator?: string,
-    package_version?: string,
+    packageVersion?: string,
     /**
      * folder name in community - added later to show the user the corresponding folder name - not used for searching
      */

--- a/src/renderer/utils/InstallerConfiguration.ts
+++ b/src/renderer/utils/InstallerConfiguration.ts
@@ -157,9 +157,18 @@ export interface AddonDependency {
  * fields from the addon's manifest.json
  */
 export interface AddonIncompatibleAddon {
+    /**
+     * Fields from the addon's manifest.json
+     * This need to be configured identically to the addon's manifest.json
+     * Leaving a field empty ignores it for the search.
+     */
     title?: string,
     creator?: string,
     package_version?: string,
+    /**
+     * folder name in community - added later to show the user the corresponding folder name - not used for searching
+     */
+    folder?: string,
     /**
      * Description of the nature of the incompatibility to display to the user in a warning dialog
      */

--- a/src/renderer/utils/InstallerConfiguration.ts
+++ b/src/renderer/utils/InstallerConfiguration.ts
@@ -154,21 +154,37 @@ export interface AddonDependency {
 }
 
 /**
- * fields from the addon's manifest.json
+ * Fields from the addon's manifest.json
  */
 export interface AddonIncompatibleAddon {
     /**
-     * Fields from the addon's manifest.json
+     * Field from the addon's manifest.json
      * This need to be configured identically to the addon's manifest.json
      * Leaving a field empty ignores it for the search.
      */
     title?: string,
+
+    /**
+     * Field from the addon's manifest.json
+     * This need to be configured identically to the addon's manifest.json
+     * Leaving a field empty ignores it for the search.
+     */
     creator?: string,
+
+    /**
+     * Field from the addon's manifest.json
+     * This need to be configured identically to the addon's manifest.json
+     * Leaving a field empty ignores it for the search.
+     *
+     * This supports semver notation.
+     */
     packageVersion?: string,
+
     /**
      * folder name in community - added later to show the user the corresponding folder name - not used for searching
      */
     folder?: string,
+
     /**
      * Description of the nature of the incompatibility to display to the user in a warning dialog
      */

--- a/src/renderer/utils/InstallerConfiguration.ts
+++ b/src/renderer/utils/InstallerConfiguration.ts
@@ -111,6 +111,7 @@ export interface Addon {
     alternativeNames?: string[],
     tracks: AddonTrack[],
     dependencies?: AddonDependency[],
+    incompatibleAddons?: AddonIncompatibleAddon[],
     configurationAspects?: ConfigurationAspect[],
     disallowedRunningExternalApps?: string[],
     backgroundService?: AddonBackgroundService,
@@ -150,6 +151,19 @@ export interface AddonDependency {
      * Modal text that shows below the dependency / parent addon on the pre-install modal (if optional) and the removal dialog (if not optional).
      */
     modalText?: string,
+}
+
+/**
+ * fields from the addon's manifest.json
+ */
+export interface AddonIncompatibleAddon {
+    title?: string,
+    creator?: string,
+    package_version?: string,
+    /**
+     * Description of the nature of the incompatibility to display to the user in a warning dialog
+     */
+    description?: string
 }
 
 export interface AddonTechSpec {


### PR DESCRIPTION
## Summary of Changes
This PR adds a configurable list of incompatible add-ons to each installable add-on. 
If searches the configured community folder and reads each folder/manifest.json to compare to the incompatibility list. 
Incompatible add-ons are listed in a warning with the recommendation to remove them. 

- [x] Split configuration for Installation folder and Community folder (two separate configs now)
- [x] Incompatibility configuration structure
- [x] Implement search logic
- [x] Warning
- [x] CleanUp / Improve code

## Screenshots (if necessary)
Example data only! List of incompatible add-ons is defined in installer-data repo. 
![image](https://user-images.githubusercontent.com/16833201/190905703-581a2d2a-c518-403e-9731-31b09c2d21e7.png)

## Testing Instructions
- Make sure to use this Installer config: https://cdn.flybywiresim.com/installer/config/pr-6.json (ask on Discord how to change)
- Configuration of Install folder and Community folder has been separated - test this as best possible
- See list of current known incompatible add-ons - install them an test Installer warning (sufficient to create a folder and place the add-on's manifest.json file in there).

Discord username (if different from GitHub): Cdr_Maverick#6475
