### PR TITLE
refactor: Configuration retrieval via CDN

### DIFF
--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -197,7 +197,7 @@ const schema: Schema<Settings> = {
             },
             configDownloadUrl: {
                 type: "string",
-                default: "https://cdn.flybywiresim.com/installer/config/staging.json",
+                default: "https://cdn.flybywiresim.com/installer/config/main.json",
             },
         },
     },

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -92,6 +92,7 @@ interface Settings {
         useDarkTheme: boolean,
         allowSeasonalEffects: boolean,
         msfsPackagePath: string,
+        configDownloadUrl: string,
     },
     cache: {
         main: {
@@ -193,6 +194,10 @@ const schema: Schema<Settings> = {
             tempLocation: {
                 type: "string",
                 default: defaultCommunityDir(),
+            },
+            configDownloadUrl: {
+                type: "string",
+                default: "https://cdn.flybywiresim.com/installer/config/staging.json",
             },
         },
     },

--- a/src/renderer/components/AddonSection/StateSection.tsx
+++ b/src/renderer/components/AddonSection/StateSection.tsx
@@ -42,8 +42,11 @@ export const StateSection: FC<StateSectionProps> = ({ publisher, addon }) => {
 
     return (
         <>
-            <BackgroundServiceBanner publisher={publisher} addon={addon} installState={dependencyAddonInstallState ?? addonInstallState} />
-            <DownloadProgressBanner addon={addon} installState={dependencyAddonInstallState ?? addonInstallState} download={dependencyAddonDownload ?? addonDownload} isDependency={isInstallingDependency} />
+            <BackgroundServiceBanner publisher={publisher} addon={addon}
+                installState={dependencyAddonInstallState ?? addonInstallState}/>
+            <DownloadProgressBanner addon={addon} installState={dependencyAddonInstallState ?? addonInstallState}
+                download={dependencyAddonDownload ?? addonDownload}
+                isDependency={isInstallingDependency}/>
         </>
     );
 };
@@ -97,7 +100,7 @@ const BackgroundServiceBanner: FC<BackgroundServiceBannerProps> = ({ publisher, 
         const bgAccentColor = isRunning ? 'bg-utility-green' : 'bg-gray-500';
 
         const handleClickAutostart = () => showModal(
-            <AutostartDialog app={app} addon={addon} publisher={publisher} isPrompted={false} />,
+            <AutostartDialog app={app} addon={addon} publisher={publisher} isPrompted={false}/>,
         );
 
         const handleStartStop = async () => {
@@ -105,7 +108,7 @@ const BackgroundServiceBanner: FC<BackgroundServiceBannerProps> = ({ publisher, 
                 const md = `Are you sure you want to shut down **${addon.name}**?. All related functionality will no longer be available.`;
 
                 const doStop = await showModalAsync(
-                    <PromptModal title={"Are you sure?"} bodyText={md} confirmColor={ButtonType.Danger} />,
+                    <PromptModal title={"Are you sure?"} bodyText={md} confirmColor={ButtonType.Danger}/>,
                 );
 
                 if (doStop) {
@@ -122,9 +125,9 @@ const BackgroundServiceBanner: FC<BackgroundServiceBannerProps> = ({ publisher, 
                     <div className="flex gap-x-7 items-center">
                         {
                             isRunning ? (
-                                <Activity size={32} className={`text-utility-green fill-current animate-pulse`} />
+                                <Activity size={32} className={`text-utility-green fill-current animate-pulse`}/>
                             ) : (
-                                <Activity size={32} className={`text-gray-500 fill-current`} />
+                                <Activity size={32} className={`text-gray-500 fill-current`}/>
                             )
                         }
 
@@ -136,17 +139,20 @@ const BackgroundServiceBanner: FC<BackgroundServiceBannerProps> = ({ publisher, 
 
                     <div className="flex gap-x-14 items-center">
                         {(addon.backgroundService.enableAutostartConfiguration ?? true) && (
-                            <span className="flex items-center gap-x-3.5 text-3xl text-quasi-white hover:text-cyan cursor-pointer" onClick={handleClickAutostart}>
-                                <Gear size={22} />
+                            <span
+                                className="flex items-center gap-x-3.5 text-3xl text-quasi-white hover:text-cyan cursor-pointer"
+                                onClick={handleClickAutostart}>
+                                <Gear size={22}/>
                                 Autostart...
                             </span>
                         )}
 
-                        <Button className="w-64" type={ButtonType.Neutral} onClick={handleStartStop}>{isRunning ? 'Stop' : 'Start'}</Button>
+                        <Button className="w-64" type={ButtonType.Neutral}
+                            onClick={handleStartStop}>{isRunning ? 'Stop' : 'Start'}</Button>
                     </div>
                 </StateContainer>
 
-                <ProgressBar className={bgAccentColor} value={100} animated={isRunning} />
+                <ProgressBar className={bgAccentColor} value={100} animated={isRunning}/>
             </div>
 
         );
@@ -162,6 +168,7 @@ interface DownloadProgressBannerProps {
     isDependency: boolean,
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const DownloadProgressBanner: FC<DownloadProgressBannerProps> = ({ addon, installState, download, isDependency }) => {
     if (!installState || !download) {
         return null;
@@ -173,7 +180,7 @@ const DownloadProgressBanner: FC<DownloadProgressBannerProps> = ({ addon, instal
     let progressBarValue;
     switch (installState.status) {
         case InstallStatus.DownloadPrep:
-            stateIcon = <Download size={40} className="text-white mr-6" />;
+            stateIcon = <Download size={40} className="text-white mr-6"/>;
             stateText = <SmallStateText>Preparing update</SmallStateText>;
             progressBarBg = 'bg-cyan';
             progressBarValue = 0;
@@ -189,7 +196,7 @@ const DownloadProgressBanner: FC<DownloadProgressBannerProps> = ({ addon, instal
                         className="text-gray-300 ml-3">part {download.progress.splitPartIndex + 1}/{download.progress.splitPartCount}</span>
                     : null;
 
-                stateIcon = <Download size={40} className="text-white mr-6" />;
+                stateIcon = <Download size={40} className="text-white mr-6"/>;
                 stateText = <SmallStateText>{`Downloading`}{part}</SmallStateText>;
                 progressBarBg = 'bg-cyan';
             }
@@ -260,7 +267,8 @@ const DownloadProgressBanner: FC<DownloadProgressBannerProps> = ({ addon, instal
 
     let moduleStateText;
     if (download.module && installState.status !== InstallStatus.DownloadCanceled) {
-        const moduleIndicator = showProgress && download.moduleCount > 1 ? <span className=" text-gray-400">{download.moduleIndex + 1}/{download.moduleCount}</span> : null;
+        const moduleIndicator = showProgress && download.moduleCount > 1 ?
+            <span className=" text-gray-400">{download.moduleIndex + 1}/{download.moduleCount}</span> : null;
 
         moduleStateText = (
             <span className="flex items-center gap-x-3 mr-12 text-white text-4xl">
@@ -309,7 +317,7 @@ const DownloadProgressBanner: FC<DownloadProgressBannerProps> = ({ addon, instal
                 )}
             </StateContainer>
 
-            <ProgressBar className={progressBarBg} value={progressBarValue} />
+            <ProgressBar className={progressBarBg} value={progressBarValue}/>
         </div>
     );
 };

--- a/src/renderer/components/SettingsSection/Developer.tsx
+++ b/src/renderer/components/SettingsSection/Developer.tsx
@@ -12,7 +12,7 @@ const index = (): JSX.Element => {
     const [configDownloadUrl, setConfigDownloadUrl] = useSetting<string>('mainSettings.configDownloadUrl');
     const [configDownloadUrlValid, setConfigDownloadUrlValid] = useState<boolean>(false);
 
-    useEffect(() => {
+    const validateUrl = () => {
         try {
             fetch(configDownloadUrl)
                 .then((response) => {
@@ -21,7 +21,11 @@ const index = (): JSX.Element => {
         } catch (e) {
             setConfigDownloadUrlValid(false);
         }
-    }, [configDownloadUrl]);
+    };
+
+    useEffect(() => {
+        validateUrl();
+    }, []);
 
     return (
         <div>
@@ -35,6 +39,7 @@ const index = (): JSX.Element => {
                                 value={configDownloadUrl}
                                 type="url"
                                 onChange={(event) => setConfigDownloadUrl(event.target.value)}
+                                onBlur={() => validateUrl()}
                                 size={50}
                             />
                         </div>

--- a/src/renderer/components/SettingsSection/Developer.tsx
+++ b/src/renderer/components/SettingsSection/Developer.tsx
@@ -1,0 +1,48 @@
+import React, { FC, useEffect, useState } from 'react';
+import { useSetting } from "common/settings";
+
+const SettingsItem: FC<{ name: string }> = ({ name, children }) => (
+    <div className="flex flex-row items-center justify-between py-3.5">
+        <p className="m-0">{name}</p>
+        {children}
+    </div>
+);
+
+const index = (): JSX.Element => {
+    const [configDownloadUrl, setConfigDownloadUrl] = useSetting<string>('mainSettings.configDownloadUrl');
+    const [configDownloadUrlValid, setConfigDownloadUrlValid] = useState<boolean>(false);
+
+    useEffect(() => {
+        try {
+            fetch(configDownloadUrl)
+                .then((response) => {
+                    setConfigDownloadUrlValid(response.status === 200);
+                });
+        } catch (e) {
+            setConfigDownloadUrlValid(false);
+        }
+    }, [configDownloadUrl]);
+
+    return (
+        <div>
+            <div className="flex flex-col">
+                <h2 className="text-white">General Settings</h2>
+                <div className="flex flex-col divide-y divide-gray-600">
+                    <SettingsItem name="Configuration Download URL">
+                        <div className='flex flex-row items-center justify-between text-white py-4'>
+                            <input
+                                className={`text-right ${configDownloadUrlValid ? 'text-green-500' : 'text-red-500'}`}
+                                value={configDownloadUrl}
+                                type="url"
+                                onChange={(event) => setConfigDownloadUrl(event.target.value)}
+                                size={50}
+                            />
+                        </div>
+                    </SettingsItem>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default index;

--- a/src/renderer/components/SettingsSection/index.tsx
+++ b/src/renderer/components/SettingsSection/index.tsx
@@ -1,10 +1,11 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import GeneralSettings from 'renderer/components/SettingsSection/General';
 import { Redirect, Route } from "react-router-dom";
 import { AboutSettings } from "renderer/components/SettingsSection/About";
 import { SideBar, SideBarLink, SideBarTitle } from "renderer/components/SideBar";
 import CustomizationSettings from './Customization';
 import DownloadSettings from './Download';
+import DeveloperSettings from './Developer';
 import settings from 'common/settings';
 import * as packageInfo from '../../../../package.json';
 import { Button, ButtonType } from '../Button';
@@ -34,6 +35,8 @@ export const ResetButton: FC<InstallButtonProps> = ({
 export const SettingsSection = (): JSX.Element => {
     const { showModal } = useModals();
 
+    const [showDevSettings, setShowDevSettings] = useState(false);
+
     const handleReset = async () => {
         showModal(
             <PromptModal
@@ -53,7 +56,13 @@ export const SettingsSection = (): JSX.Element => {
         <div className="w-full bg-navy-lighter text-white overflow-hidden">
             <div className="w-full h-full flex flex-row items-stretch">
                 <SideBar className="flex-shrink-0">
-                    <SideBarTitle>Settings</SideBarTitle>
+                    <div onClick={(event) => {
+                        if (event.ctrlKey && event.altKey) {
+                            setShowDevSettings((old) => !old);
+                        }
+                    }}>
+                        <SideBarTitle>Settings</SideBarTitle>
+                    </div>
 
                     <SideBarLink to="/settings/general">
                         <span className="text-3xl font-manrope font-semibold">
@@ -73,6 +82,14 @@ export const SettingsSection = (): JSX.Element => {
                     {/*    </span>*/}
                     {/*</SideBarLink>*/}
 
+                    {showDevSettings && (
+                        <SideBarLink to="/settings/developer">
+                            <span className="text-3xl font-manrope font-semibold">
+                            Developer
+                            </span>
+                        </SideBarLink>
+                    )}
+
                     <SideBarLink to="/settings/about">
                         <span className="text-3xl font-manrope font-semibold">
                             About
@@ -91,19 +108,25 @@ export const SettingsSection = (): JSX.Element => {
                     </Route>
 
                     <Route path="/settings/general">
-                        <GeneralSettings />
+                        <GeneralSettings/>
                     </Route>
 
                     <Route path="/settings/download">
-                        <DownloadSettings />
+                        <DownloadSettings/>
                     </Route>
 
                     <Route path="/settings/customization">
-                        <CustomizationSettings />
+                        <CustomizationSettings/>
                     </Route>
 
+                    {showDevSettings && (
+                        <Route path="/settings/developer">
+                            <DeveloperSettings/>
+                        </Route>
+                    )}
+
                     <Route path="/settings/about">
-                        <AboutSettings />
+                        <AboutSettings/>
                     </Route>
                 </div>
             </div>

--- a/src/renderer/data.ts
+++ b/src/renderer/data.ts
@@ -1,6 +1,7 @@
 import { Configuration } from "./utils/InstallerConfiguration";
 
 export const defaultConfiguration: Configuration = {
+    version: 1,
     publishers: [
         {
             name: 'FlyByWire Simulations',
@@ -147,6 +148,7 @@ export const defaultConfiguration: Configuration = {
                             modalText: 'SimBridge allows the A32NX to expose remote tools like the Web MCDU, as well as use the external terrain database.',
                         },
                     ],
+                    incompatibleAddons: [],
                     myInstallPage: {
                         links: [
                             {

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -92,13 +92,14 @@ InstallerConfiguration.obtain().then((config: Configuration) => {
         }
     }
 
-    console.log(config);
+    console.log("Using this configuration:", config);
+
     Directories.removeAllTemp();
     ReactDOM.render(
         <Provider store={store}>
             <MemoryRouter>
                 <ModalProvider>
-                    <App />
+                    <App/>
                 </ModalProvider>
             </MemoryRouter>
         </Provider>,
@@ -110,7 +111,9 @@ InstallerConfiguration.obtain().then((config: Configuration) => {
             <span className="text-5xl font-semibold">Something went very wrong.</span>
             <span className="w-3/5 text-center text-2xl">We could not configure your installer. Please seek support on the Discord #support channel or on GitHub and provide a screenshot of the following information:</span>
             <pre className="w-3/5 bg-gray-700 text-2xl font-mono px-6 py-2.5 mb-0 rounded-lg">{error.stack}</pre>
-            <button className="bg-navy-lightest hover:bg-navy-lighter px-5 py-2 text-lg font-semibold rounded-lg" onClick={() => ipcRenderer.send(channels.window.close)}>Close the Installer</button>
+            <button className="bg-navy-lightest hover:bg-navy-lighter px-5 py-2 text-lg font-semibold rounded-lg"
+                onClick={() => ipcRenderer.send(channels.window.close)}>Close the Installer
+            </button>
         </div>,
         document.getElementById('root'),
     );

--- a/src/renderer/redux/features/configuration.ts
+++ b/src/renderer/redux/features/configuration.ts
@@ -2,7 +2,7 @@ import { createSlice } from "@reduxjs/toolkit";
 import { TypedAction } from "../store";
 import { Configuration } from "renderer/utils/InstallerConfiguration";
 
-const initialState: Configuration = { publishers: [] };
+const initialState: Configuration = { version: 0, publishers: [] };
 
 export const configurationSlice = createSlice({
     name: "configuration",

--- a/src/renderer/utils/InstallerConfiguration.ts
+++ b/src/renderer/utils/InstallerConfiguration.ts
@@ -344,23 +344,23 @@ export class InstallerConfiguration {
                 console.log("Configuration from CDN is valid");
                 return config;
             } else {
-                console.warn('Network configuration was invalid, using local configuration');
+                console.warn('CDN configuration was invalid, using local configuration');
                 return this.loadConfigurationFromLocalStorage().then((config) => {
                     if (this.isConfigurationValid(config)) {
                         console.log("Configuration from local storage is valid");
                         return config;
                     } else {
-                        return Promise.reject('Both network and local configurations are invalid');
+                        return Promise.reject('Both CDN and local configurations are invalid');
                     }
                 });
             }
         }).catch(() => {
             return this.loadConfigurationFromLocalStorage().then((config) => {
                 if (this.isConfigurationValid(config)) {
-                    console.warn('Network configuration could not be loaded, using local configuration');
+                    console.warn('CDN configuration could not be loaded, using local configuration');
                     return config;
                 } else {
-                    return Promise.reject('Could not retrieve network configuration, and local configuration is invalid');
+                    return Promise.reject('Could not retrieve CDN configuration, and local configuration is invalid');
                 }
             });
         });

--- a/src/renderer/utils/InstallerConfiguration.ts
+++ b/src/renderer/utils/InstallerConfiguration.ts
@@ -314,12 +314,16 @@ export type Configuration = {
 export class InstallerConfiguration {
 
     static async obtain(): Promise<Configuration> {
-        return this.fetchConfigurationFromApi().then((config) => {
+        console.log("Obtaining configuration");
+        return this.fetchConfigurationFromCdn().then((config) => {
             if (this.isConfigurationValid(config)) {
+                console.log("Configuration from API is valid");
                 return config;
             } else {
+                console.warn('Network configuration was invalid, using local configuration');
                 return this.loadConfigurationFromLocalStorage().then((config) => {
                     if (this.isConfigurationValid(config)) {
+                        console.log("Configuration from local storage is valid");
                         return config;
                     } else {
                         return Promise.reject('Both network and local configurations are invalid');
@@ -338,7 +342,7 @@ export class InstallerConfiguration {
         });
     }
 
-    private static async fetchConfigurationFromApi(): Promise<Configuration> {
+    private static async fetchConfigurationFromCdn(): Promise<Configuration> {
         return defaultConfiguration;
     }
 


### PR DESCRIPTION
## Summary of Changes
The PR implements that the Installer fetches the configuration data from the FlyByWire CDN (fallback is still local config). 
The URL is configurable. 

## Additional context
See https://github.com/flybywiresim/installer-data/tree/staging

Discord username (if different from GitHub): Cdr_Maverick#6475
