### PR TITLE
feat: cdn-based configuration

### DIFF
--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -197,7 +197,7 @@ const schema: Schema<Settings> = {
             },
             configDownloadUrl: {
                 type: "string",
-                default: "https://cdn.flybywiresim.com/installer/config/staging.json",
+                default: "https://cdn.flybywiresim.com/installer/config/production.json",
             },
         },
     },

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -92,6 +92,7 @@ interface Settings {
         useDarkTheme: boolean,
         allowSeasonalEffects: boolean,
         msfsPackagePath: string,
+        configDownloadUrl: string,
     },
     cache: {
         main: {
@@ -193,6 +194,10 @@ const schema: Schema<Settings> = {
             tempLocation: {
                 type: "string",
                 default: defaultCommunityDir(),
+            },
+            configDownloadUrl: {
+                type: "string",
+                default: "https://cdn.flybywiresim.com/installer/config/staging.json",
             },
         },
     },

--- a/src/renderer/components/AddonSection/StateSection.tsx
+++ b/src/renderer/components/AddonSection/StateSection.tsx
@@ -162,7 +162,7 @@ interface DownloadProgressBannerProps {
     isDependency: boolean,
 }
 
-const DownloadProgressBanner: FC<DownloadProgressBannerProps> = ({ addon, installState, download, isDependency }) => {
+const DownloadProgressBanner: FC<DownloadProgressBannerProps> = ({ addon, installState, download }) => {
     if (!installState || !download) {
         return null;
     }

--- a/src/renderer/components/SettingsSection/Developer.tsx
+++ b/src/renderer/components/SettingsSection/Developer.tsx
@@ -1,0 +1,53 @@
+import React, { FC, useEffect, useState } from 'react';
+import { useSetting } from "common/settings";
+
+const SettingsItem: FC<{ name: string }> = ({ name, children }) => (
+    <div className="flex flex-row items-center justify-between py-3.5">
+        <p className="m-0">{name}</p>
+        {children}
+    </div>
+);
+
+const index = (): JSX.Element => {
+    const [configDownloadUrl, setConfigDownloadUrl] = useSetting<string>('mainSettings.configDownloadUrl');
+    const [configDownloadUrlValid, setConfigDownloadUrlValid] = useState<boolean>(false);
+
+    const validateUrl = () => {
+        try {
+            fetch(configDownloadUrl)
+                .then((response) => {
+                    setConfigDownloadUrlValid(response.status === 200);
+                });
+        } catch (e) {
+            setConfigDownloadUrlValid(false);
+        }
+    };
+
+    useEffect(() => {
+        validateUrl();
+    }, []);
+
+    return (
+        <div>
+            <div className="flex flex-col">
+                <h2 className="text-white">General Settings</h2>
+                <div className="flex flex-col divide-y divide-gray-600">
+                    <SettingsItem name="Configuration Download URL">
+                        <div className='flex flex-row items-center justify-between text-white py-4'>
+                            <input
+                                className={`text-right ${configDownloadUrlValid ? 'text-green-500' : 'text-red-500'}`}
+                                value={configDownloadUrl}
+                                type="url"
+                                onChange={(event) => setConfigDownloadUrl(event.target.value)}
+                                onBlur={() => validateUrl()}
+                                size={50}
+                            />
+                        </div>
+                    </SettingsItem>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default index;

--- a/src/renderer/components/SettingsSection/index.tsx
+++ b/src/renderer/components/SettingsSection/index.tsx
@@ -1,10 +1,11 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import GeneralSettings from 'renderer/components/SettingsSection/General';
 import { Redirect, Route } from "react-router-dom";
 import { AboutSettings } from "renderer/components/SettingsSection/About";
 import { SideBar, SideBarLink, SideBarTitle } from "renderer/components/SideBar";
 import CustomizationSettings from './Customization';
 import DownloadSettings from './Download';
+import DeveloperSettings from './Developer';
 import settings from 'common/settings';
 import * as packageInfo from '../../../../package.json';
 import { Button, ButtonType } from '../Button';
@@ -34,6 +35,8 @@ export const ResetButton: FC<InstallButtonProps> = ({
 export const SettingsSection = (): JSX.Element => {
     const { showModal } = useModals();
 
+    const [showDevSettings, setShowDevSettings] = useState(false);
+
     const handleReset = async () => {
         showModal(
             <PromptModal
@@ -53,7 +56,13 @@ export const SettingsSection = (): JSX.Element => {
         <div className="w-full bg-navy-lighter text-white overflow-hidden">
             <div className="w-full h-full flex flex-row items-stretch">
                 <SideBar className="flex-shrink-0">
-                    <SideBarTitle>Settings</SideBarTitle>
+                    <div onClick={(event) => {
+                        if (event.ctrlKey && event.altKey) {
+                            setShowDevSettings((old) => !old);
+                        }
+                    }}>
+                        <SideBarTitle>Settings</SideBarTitle>
+                    </div>
 
                     <SideBarLink to="/settings/general">
                         <span className="text-3xl font-manrope font-semibold">
@@ -72,6 +81,14 @@ export const SettingsSection = (): JSX.Element => {
                     {/*        Customization*/}
                     {/*    </span>*/}
                     {/*</SideBarLink>*/}
+
+                    {showDevSettings && (
+                        <SideBarLink to="/settings/developer">
+                            <span className="text-3xl font-manrope font-semibold">
+                            Developer
+                            </span>
+                        </SideBarLink>
+                    )}
 
                     <SideBarLink to="/settings/about">
                         <span className="text-3xl font-manrope font-semibold">
@@ -101,6 +118,12 @@ export const SettingsSection = (): JSX.Element => {
                     <Route path="/settings/customization">
                         <CustomizationSettings />
                     </Route>
+
+                    {showDevSettings && (
+                        <Route path="/settings/developer">
+                            <DeveloperSettings />
+                        </Route>
+                    )}
 
                     <Route path="/settings/about">
                         <AboutSettings />

--- a/src/renderer/data.ts
+++ b/src/renderer/data.ts
@@ -1,6 +1,7 @@
 import { Configuration } from "./utils/InstallerConfiguration";
 
 export const defaultConfiguration: Configuration = {
+    version: 1,
     publishers: [
         {
             name: 'FlyByWire Simulations',
@@ -147,6 +148,7 @@ export const defaultConfiguration: Configuration = {
                             modalText: 'SimBridge allows the A32NX to expose remote tools like the Web MCDU, as well as use the external terrain database.',
                         },
                     ],
+                    incompatibleAddons: [],
                     myInstallPage: {
                         links: [
                             {

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -92,13 +92,14 @@ InstallerConfiguration.obtain().then((config: Configuration) => {
         }
     }
 
-    console.log(config);
+    console.log("Using this configuration:", config);
+
     Directories.removeAllTemp();
     ReactDOM.render(
         <Provider store={store}>
             <MemoryRouter>
                 <ModalProvider>
-                    <App />
+                    <App/>
                 </ModalProvider>
             </MemoryRouter>
         </Provider>,

--- a/src/renderer/redux/features/configuration.ts
+++ b/src/renderer/redux/features/configuration.ts
@@ -2,7 +2,7 @@ import { createSlice } from "@reduxjs/toolkit";
 import { TypedAction } from "../store";
 import { Configuration } from "renderer/utils/InstallerConfiguration";
 
-const initialState: Configuration = { publishers: [] };
+const initialState: Configuration = { version: 0, publishers: [] };
 
 export const configurationSlice = createSlice({
     name: "configuration",


### PR DESCRIPTION
## Summary of Changes
The PR implements that the Installer fetches the configuration data from the FlyByWire CDN (fallback is still local config). 
The URL is configurable. 

## Additional context
See https://github.com/flybywiresim/installer-data/tree/staging