### PR TITLE
fix: improve free disk space check

### DIFF
--- a/src/renderer/utils/FreeDiskSpace.ts
+++ b/src/renderer/utils/FreeDiskSpace.ts
@@ -1,0 +1,54 @@
+import { Directories } from "renderer/utils/Directories";
+import fs from 'fs-extra';
+import checkDiskSpace from "check-disk-space";
+
+export enum FreeDiskSpaceStatus {
+    NotLimited,
+    LimitedByDestination,
+    LimitedByTemporary,
+    LimitedByBoth,
+}
+
+export interface FreeDiskSpaceInfo {
+    freeSpaceInDest: number,
+    freeSpaceInTemp: number,
+    status: FreeDiskSpaceStatus,
+}
+
+export class FreeDiskSpace {
+
+    static async analyse(requiredSpace: number): Promise<FreeDiskSpaceInfo> {
+        let resolvedDestDir = Directories.installLocation();
+        let resolvedTempDir = Directories.tempLocation();
+
+        try {
+            resolvedDestDir = await fs.readlink(resolvedDestDir);
+        } catch (e) {
+            // noop - it's probably not a link
+        }
+
+        try {
+            resolvedTempDir = await fs.readlink(resolvedTempDir);
+        } catch (e) {
+            // noop - it's probably not a link
+        }
+
+        const freeDestDirSpace = (await checkDiskSpace(resolvedDestDir)).free;
+        const freeTempDirSpace = (await checkDiskSpace(resolvedTempDir)).free;
+
+        let status: FreeDiskSpaceStatus;
+        if (requiredSpace >= freeDestDirSpace && requiredSpace >= freeTempDirSpace) {
+            status = FreeDiskSpaceStatus.LimitedByBoth;
+        } else if (requiredSpace >= freeDestDirSpace) {
+            status = FreeDiskSpaceStatus.LimitedByDestination;
+        } else if (requiredSpace >= freeTempDirSpace) {
+            status = FreeDiskSpaceStatus.LimitedByTemporary;
+        }
+
+        return {
+            freeSpaceInDest: freeDestDirSpace,
+            freeSpaceInTemp: freeTempDirSpace,
+            status,
+        };
+    }
+}


### PR DESCRIPTION
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

* Free disk space check now takes symlinks into account
* Free disk space check now also verifies temporary directory
  * Space is shown separately on modal if temporary directory is different than destination directory

## Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/4503241/210688289-e99d8d0f-4e8e-4a23-b602-ef592c23edec.png)
*disregard WIP new addon UI - not part of PR*

