### PR TITLE
fix: git install detection

### DIFF
--- a/src/renderer/utils/Directories.ts
+++ b/src/renderer/utils/Directories.ts
@@ -145,7 +145,7 @@ export class Directories {
 
         try {
             const symlinkPath = fs.readlinkSync(targetDir);
-            if (symlinkPath && fs.existsSync(path.join(symlinkPath, '/../.git'))) {
+            if (symlinkPath && fs.existsSync(path.join(symlinkPath, '/../../../.git'))) {
                 console.log('Is git repo', targetDir);
                 return true;
             }


### PR DESCRIPTION
<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
After the recent repo refactor, the final output of the A320 has moved further into the directory structure, meaning the `.git` folder is now 3 directories up instead of 1. This fixes it so the installer can once again detect git installs.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
