### PR TITLE
refactor: remove antd and antd icons

### DIFF
--- a/.github/CHANGELOG.yaml
+++ b/.github/CHANGELOG.yaml
@@ -9,11 +9,11 @@
 
 
 releases:
-  - - name: 3.3.4
-      changes:
-        - title: Added check for incompatible add-ons
-          categories: [ Addons ]
-          authors: [ Cdr_Maverick ]
+  - name: 3.3.4
+    changes:
+      - title: Added check for incompatible add-ons
+        categories: [ Addons ]
+        authors: [ Cdr_Maverick ]
   - name: 3.2.2
     changes:
       - title: Update dependency to mitigate potential security issue

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "3.4.0-dev.1",
       "license": "GPL-3.0",
       "dependencies": {
-        "@ant-design/icons": "^4.4.0",
         "@flybywiresim/fragmenter": "^0.7.4",
         "@flybywiresim/react-components": "^0.2.5",
         "@reduxjs/toolkit": "^1.7.1",
@@ -19,7 +18,6 @@
         "@types/js-yaml": "^4.0.5",
         "@types/winreg": "^1.2.31",
         "@types/ws": "^8.5.3",
-        "antd": "^4.12.2",
         "check-disk-space": "^3.3.1",
         "config-ini-parser": "~1.5.9",
         "dateformat": "^5.0.1",
@@ -117,49 +115,6 @@
       "optionalDependencies": {
         "bufferutil": "^4.0.6",
         "utf-8-validate": "^5.0.9"
-      }
-    },
-    "node_modules/@ant-design/colors": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-6.0.0.tgz",
-      "integrity": "sha512-qAZRvPzfdWHtfameEGP2Qvuf838NhergR35o+EuVyB5XvSA98xod5r4utvi4TJ3ywmevm290g9nsCG5MryrdWQ==",
-      "dependencies": {
-        "@ctrl/tinycolor": "^3.4.0"
-      }
-    },
-    "node_modules/@ant-design/icons": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-4.6.2.tgz",
-      "integrity": "sha512-QsBG2BxBYU/rxr2eb8b2cZ4rPKAPBpzAR+0v6rrZLp/lnyvflLH3tw1vregK+M7aJauGWjIGNdFmUfpAOtw25A==",
-      "dependencies": {
-        "@ant-design/colors": "^6.0.0",
-        "@ant-design/icons-svg": "^4.0.0",
-        "@babel/runtime": "^7.11.2",
-        "classnames": "^2.2.6",
-        "rc-util": "^5.9.4"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0"
-      }
-    },
-    "node_modules/@ant-design/icons-svg": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.1.0.tgz",
-      "integrity": "sha512-Fi03PfuUqRs76aI3UWYpP864lkrfPo0hluwGqh7NJdLhvH4iRDc3jbJqZIvRDLHKbXrvAfPPV3+zjUccfFvWOQ=="
-    },
-    "node_modules/@ant-design/react-slick": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-0.28.2.tgz",
-      "integrity": "sha512-nkrvXsO29pLToFaBb3MlJY4McaUFR4UHtXTz6A5HBzYmxH4SwKerX54mWdGc/6tKpHvS3vUwjEOt2T5XqZEo8Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.4",
-        "classnames": "^2.2.5",
-        "json2mq": "^0.2.0",
-        "lodash": "^4.17.15",
-        "resize-observer-polyfill": "^1.5.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1540,14 +1495,6 @@
       "dev": true,
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/@ctrl/tinycolor": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.0.tgz",
-      "integrity": "sha512-JZButFdZ1+/xAfpguQHoabIXkcqRRKpMrWKBkpEZZyxfY9C1DpADFB8PEqGSTeFr135SaTRfKqGKx5xSCLI7ZQ==",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -4113,63 +4060,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/antd": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-4.15.0.tgz",
-      "integrity": "sha512-24HMixmQAhCyqb0ND5wX5DYRTbPactCT36mfVKowqgr77eT7XQ59Uu6aS513mbeiVhXcHrNlrlCKNZBSeEDgPg==",
-      "dependencies": {
-        "@ant-design/colors": "^6.0.0",
-        "@ant-design/icons": "^4.6.2",
-        "@ant-design/react-slick": "~0.28.1",
-        "@babel/runtime": "^7.12.5",
-        "array-tree-filter": "^2.1.0",
-        "classnames": "^2.2.6",
-        "copy-to-clipboard": "^3.2.0",
-        "lodash": "^4.17.20",
-        "moment": "^2.25.3",
-        "rc-cascader": "~1.4.0",
-        "rc-checkbox": "~2.3.0",
-        "rc-collapse": "~3.1.0",
-        "rc-dialog": "~8.5.1",
-        "rc-drawer": "~4.3.0",
-        "rc-dropdown": "~3.2.0",
-        "rc-field-form": "~1.20.0",
-        "rc-image": "~5.2.4",
-        "rc-input-number": "~7.0.1",
-        "rc-mentions": "~1.5.0",
-        "rc-menu": "~8.10.0",
-        "rc-motion": "^2.4.0",
-        "rc-notification": "~4.5.2",
-        "rc-pagination": "~3.1.6",
-        "rc-picker": "~2.5.10",
-        "rc-progress": "~3.1.0",
-        "rc-rate": "~2.9.0",
-        "rc-resize-observer": "^1.0.0",
-        "rc-select": "~12.1.6",
-        "rc-slider": "~9.7.1",
-        "rc-steps": "~4.1.0",
-        "rc-switch": "~3.2.0",
-        "rc-table": "~7.13.0",
-        "rc-tabs": "~11.7.0",
-        "rc-textarea": "~0.3.0",
-        "rc-tooltip": "~5.1.0",
-        "rc-tree": "~4.1.0",
-        "rc-tree-select": "~4.3.0",
-        "rc-trigger": "^5.2.1",
-        "rc-upload": "~4.2.0-alpha.0",
-        "rc-util": "^5.9.4",
-        "scroll-into-view-if-needed": "^2.2.25",
-        "warning": "^4.0.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ant-design"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
     "node_modules/anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -4375,11 +4265,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array-tree-filter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-tree-filter/-/array-tree-filter-2.1.0.tgz",
-      "integrity": "sha512-4ROwICNlNw/Hqa9v+rk5h22KjmzB1JGTMVKP2AKJBOCgb0yL0ASf0+YvCcLNNwquOHNX48jkeZIJ3a+oOQqKcw=="
-    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -4462,11 +4347,6 @@
       "engines": {
         "node": ">=0.12.0"
       }
-    },
-    "node_modules/async-validator": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-3.5.1.tgz",
-      "integrity": "sha512-DDmKA7sdSAJtTVeNZHrnr2yojfFaoeW8MfQN8CeuXg8DDQHTqKk9Fdv38dSvnesHoO8MUwMI2HphOeSyIF+wmQ=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -5396,11 +5276,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
-    },
     "node_modules/clean-css": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.2.2.tgz",
@@ -5669,11 +5544,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
-    },
-    "node_modules/compute-scroll-into-view": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
-      "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -5960,14 +5830,6 @@
       "dev": true,
       "dependencies": {
         "is-what": "^3.12.0"
-      }
-    },
-    "node_modules/copy-to-clipboard": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
-      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
-      "dependencies": {
-        "toggle-selection": "^1.0.6"
       }
     },
     "node_modules/core-js": {
@@ -6437,6 +6299,7 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.19.0.tgz",
       "integrity": "sha512-X3bf2iTPgCAQp9wvjOQytnf5vO5rESYRXlPIVcgSbtT5OTScPcsf9eZU+B/YIkKAtYr5WeCii58BgATrNitlWg==",
+      "dev": true,
       "engines": {
         "node": ">=0.11"
       },
@@ -6452,12 +6315,6 @@
       "engines": {
         "node": ">=12.20"
       }
-    },
-    "node_modules/dayjs": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.3.tgz",
-      "integrity": "sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A==",
-      "peer": true
     },
     "node_modules/debounce-fn": {
       "version": "4.0.0",
@@ -6915,11 +6772,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/dom-align": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.0.tgz",
-      "integrity": "sha512-YkoezQuhp3SLFGdOlr5xkqZ640iXrnHAwVYcDg8ZKRUtO7mSzSC2BA5V0VuyAwPSJA4CLIc6EDDJh4bEsD2+zA=="
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -10765,14 +10617,6 @@
       "dev": true,
       "optional": true
     },
-    "node_modules/json2mq": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
-      "integrity": "sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=",
-      "dependencies": {
-        "string-convert": "^0.2.0"
-      }
-    },
     "node_modules/json5": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
@@ -12570,19 +12414,6 @@
         "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/mini-store": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/mini-store/-/mini-store-3.0.6.tgz",
-      "integrity": "sha512-YzffKHbYsMQGUWQRKdsearR79QsMzzJcDDmZKlJBqt5JNkqpyJHYlK6gP61O36X+sLf76sO9G6mhKBe83gIZIQ==",
-      "dependencies": {
-        "hoist-non-react-statics": "^3.3.2",
-        "shallowequal": "^1.0.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -12778,14 +12609,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -16464,556 +16287,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/rc-align": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.9.tgz",
-      "integrity": "sha512-myAM2R4qoB6LqBul0leaqY8gFaiECDJ3MtQDmzDo9xM9NRT/04TvWOYd2YHU9zvGzqk9QXF6S9/MifzSKDZeMw==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "dom-align": "^1.7.0",
-        "rc-util": "^5.3.0",
-        "resize-observer-polyfill": "^1.5.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-cascader": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-1.4.2.tgz",
-      "integrity": "sha512-JVuLGrSi+3G8DZyPvlKlGVWJjhoi9NTz6REHIgRspa5WnznRkKGm2ejb0jJtz0m2IL8Q9BG4ZA2sXuqAu71ltQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "array-tree-filter": "^2.1.0",
-        "rc-trigger": "^5.0.4",
-        "rc-util": "^5.0.1",
-        "warning": "^4.0.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-checkbox": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-2.3.2.tgz",
-      "integrity": "sha512-afVi1FYiGv1U0JlpNH/UaEXdh6WUJjcWokj/nUN2TgG80bfG+MDdbfHKlLcNNba94mbjy2/SXJ1HDgrOkXGAjg==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-collapse": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.1.0.tgz",
-      "integrity": "sha512-EwpNPJcLe7b+5JfyaxM9ZNnkCgqArt3QQO0Cr5p5plwz/C9h8liAmjYY5I4+hl9lAjBqb7ZwLu94+z+rt5g1WQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.3.4",
-        "rc-util": "^5.2.1",
-        "shallowequal": "^1.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-dialog": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-8.5.2.tgz",
-      "integrity": "sha512-3n4taFcjqhTE9uNuzjB+nPDeqgRBTEGBfe46mb1e7r88DgDo0lL4NnxY/PZ6PJKd2tsCt+RrgF/+YeTvJ/Thsw==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.6",
-        "rc-motion": "^2.3.0",
-        "rc-util": "^5.6.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-drawer": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-4.3.1.tgz",
-      "integrity": "sha512-GMfFy4maqxS9faYXEhQ+0cA1xtkddEQzraf6SAdzWbn444DrrLogwYPk1NXSpdXjLCLxgxOj9MYtyYG42JsfXg==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.6",
-        "rc-util": "^5.7.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-dropdown": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-3.2.0.tgz",
-      "integrity": "sha512-j1HSw+/QqlhxyTEF6BArVZnTmezw2LnSmRk6I9W7BCqNCKaRwleRmMMs1PHbuaG8dKHVqP6e21RQ7vPBLVnnNw==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.6",
-        "rc-trigger": "^5.0.4"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/rc-field-form": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-1.20.0.tgz",
-      "integrity": "sha512-jkzsIfXR7ywEYdeAtktt1aLff88wxIPDLpq7KShHNl4wlsWrCE+TzkXBfjvVzYOVZt5GGrD8YDqNO/q6eaR/eA==",
-      "dependencies": {
-        "@babel/runtime": "^7.8.4",
-        "async-validator": "^3.0.3",
-        "rc-util": "^5.8.0"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">= 16.9.0",
-        "react-dom": ">= 16.9.0"
-      }
-    },
-    "node_modules/rc-image": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-5.2.4.tgz",
-      "integrity": "sha512-kWOjhZC1OoGKfvWqtDoO9r8WUNswBwnjcstI6rf7HMudz0usmbGvewcWqsOhyaBRJL9+I4eeG+xiAoxV1xi75Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2",
-        "classnames": "^2.2.6",
-        "rc-dialog": "~8.5.0",
-        "rc-util": "^5.0.6"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-input-number": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-7.0.3.tgz",
-      "integrity": "sha512-y0nVqVANWyxQbm/vdhz1p5E1V5Y6Yd2+3MGKntSzCxrYgw0F7/COXkbRdcTECnXwiDv8ZrbYQ1pTP3u43PqE4Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.5",
-        "rc-util": "^5.0.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-mentions": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-1.5.3.tgz",
-      "integrity": "sha512-NG/KB8YiKBCJPHHvr/QapAb4f9YzLJn7kDHtmI1K6t7ZMM5YgrjIxNNhoRKKP9zJvb9PdPts69Hbg4ZMvLVIFQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.6",
-        "rc-menu": "^8.0.1",
-        "rc-textarea": "^0.3.0",
-        "rc-trigger": "^5.0.4",
-        "rc-util": "^5.0.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-menu": {
-      "version": "8.10.7",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-8.10.7.tgz",
-      "integrity": "sha512-m/ypV7OjkkUsMdutzMUxEI8tWyi0Y1TQ5YkSDk7k2uv2aCKkHYEoDKsDAfcPeejo3HMo2z5unWE+jD+dCphraw==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "mini-store": "^3.0.1",
-        "rc-motion": "^2.0.1",
-        "rc-trigger": "^5.1.2",
-        "rc-util": "^5.7.0",
-        "resize-observer-polyfill": "^1.5.0",
-        "shallowequal": "^1.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-motion": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.4.1.tgz",
-      "integrity": "sha512-TWLvymfMu8SngPx5MDH8dQ0D2RYbluNTfam4hY/dNNx9RQ3WtGuZ/GXHi2ymLMzH+UNd6EEFYkOuR5JTTtm8Xg==",
-      "dependencies": {
-        "@babel/runtime": "^7.11.1",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.2.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-notification": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-4.5.5.tgz",
-      "integrity": "sha512-YIfhTSw+h5GsSdgMnuMx24wqiPlg3FeamuOlkh9RkyHx+SeZVAKzQ0juy2NGvPEF2hDWi5xTqxUqLdo0L2AmGg==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.2.0",
-        "rc-util": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-overflow": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.0.2.tgz",
-      "integrity": "sha512-GXj4DAyNxm4f57LvXLwhJaZoJHzSge2l2lQq64MZP7NJAfLpQqOLD+v9JMV9ONTvDPZe8kdzR+UMmkAn7qlzFA==",
-      "dependencies": {
-        "@babel/runtime": "^7.11.1",
-        "classnames": "^2.2.1",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.5.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-pagination": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-3.1.6.tgz",
-      "integrity": "sha512-Pb2zJEt8uxXzYCWx/2qwsYZ3vSS9Eqdw0cJBli6C58/iYhmvutSBqrBJh51Z5UzYc5ZcW5CMeP5LbbKE1J3rpw==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-picker": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-2.5.10.tgz",
-      "integrity": "sha512-d2or2jql9SSY8CaRPybpbKkXBq3bZ6g88UKyWQZBLTCrc92Xm87RfRC/P3UEQo/CLmia3jVF7IXVi1HmNe2DZA==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1",
-        "date-fns": "^2.15.0",
-        "moment": "^2.24.0",
-        "rc-trigger": "^5.0.4",
-        "rc-util": "^5.4.0",
-        "shallowequal": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "dayjs": "^1.8.30",
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-progress": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-3.1.3.tgz",
-      "integrity": "sha512-Jl4fzbBExHYMoC6HBPzel0a9VmhcSXx24LVt/mdhDM90MuzoMCJjXZAlhA0V0CJi+SKjMhfBoIQ6Lla1nD4QNw==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.6"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-rate": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/rc-rate/-/rc-rate-2.9.1.tgz",
-      "integrity": "sha512-MmIU7FT8W4LYRRHJD1sgG366qKtSaKb67D0/vVvJYR0lrCuRrCiVQ5qhfT5ghVO4wuVIORGpZs7ZKaYu+KMUzA==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.5",
-        "rc-util": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-resize-observer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.0.0.tgz",
-      "integrity": "sha512-RgKGukg1mlzyGdvzF7o/LGFC8AeoMH9aGzXTUdp6m+OApvmRdUuOscq/Y2O45cJA+rXt1ApWlpFoOIioXL3AGg==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.0.0",
-        "resize-observer-polyfill": "^1.5.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-select": {
-      "version": "12.1.7",
-      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-12.1.7.tgz",
-      "integrity": "sha512-sLZlfp+U7Typ+jPM5gTi8I4/oJalRw8kyhxZZ9Q4mEfO2p+otd1Chmzhh+wPraBY3IwE0RZM2/x1Leg/kQKk/w==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.0.1",
-        "rc-overflow": "^1.0.0",
-        "rc-trigger": "^5.0.4",
-        "rc-util": "^5.0.1",
-        "rc-virtual-list": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/rc-slider": {
-      "version": "9.7.2",
-      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-9.7.2.tgz",
-      "integrity": "sha512-mVaLRpDo6otasBs6yVnG02ykI3K6hIrLTNfT5eyaqduFv95UODI9PDS6fWuVVehVpdS4ENgOSwsTjrPVun+k9g==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.5",
-        "rc-tooltip": "^5.0.1",
-        "rc-util": "^5.0.0",
-        "shallowequal": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-steps": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-4.1.3.tgz",
-      "integrity": "sha512-GXrMfWQOhN3sVze3JnzNboHpQdNHcdFubOETUHyDpa/U3HEKBZC3xJ8XK4paBgF4OJ3bdUVLC+uBPc6dCxvDYA==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.2",
-        "classnames": "^2.2.3",
-        "rc-util": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-switch": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-3.2.2.tgz",
-      "integrity": "sha512-+gUJClsZZzvAHGy1vZfnwySxj+MjLlGRyXKXScrtCTcmiYNPzxDFOxdQ/3pK1Kt/0POvwJ/6ALOR8gwdXGhs+A==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.0.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-table": {
-      "version": "7.13.3",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.13.3.tgz",
-      "integrity": "sha512-oP4fknjvKCZAaiDnvj+yzBaWcg+JYjkASbeWonU1BbrLcomkpKvMUgPODNEzg0QdXA9OGW0PO86h4goDSW06Kg==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.5",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.4.0",
-        "shallowequal": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-tabs": {
-      "version": "11.7.3",
-      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-11.7.3.tgz",
-      "integrity": "sha512-5nd2NVss9TprPRV9r8N05SjQyAE7zDrLejxFLcbJ+BdLxSwnGnk3ws/Iq0smqKZUnPQC0XEvnpF3+zlllUUT2w==",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2",
-        "classnames": "2.x",
-        "rc-dropdown": "^3.1.3",
-        "rc-menu": "^8.6.1",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-textarea": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-0.3.4.tgz",
-      "integrity": "sha512-ILUYx831ZukQPv3m7R4RGRtVVWmL1LV4ME03L22mvT56US0DGCJJaRTHs4vmpcSjFHItph5OTmhodY4BOwy81A==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.7.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-tooltip": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-5.1.0.tgz",
-      "integrity": "sha512-pFqD1JZwNIpbdcefB7k5xREoHAWM/k3yQwYF0iminbmDXERgq4rvBfUwIvlCqqZSM7HDr9hYeYr6ZsVNaKtvCQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2",
-        "rc-trigger": "^5.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-tree": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-4.1.5.tgz",
-      "integrity": "sha512-q2vjcmnBDylGZ9/ZW4F9oZMKMJdbFWC7um+DAQhZG1nqyg1iwoowbBggUDUaUOEryJP+08bpliEAYnzJXbI5xQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.0.1",
-        "rc-util": "^5.0.0",
-        "rc-virtual-list": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/rc-tree-select": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-4.3.1.tgz",
-      "integrity": "sha512-OeV8u5kBEJ8MbatP04Rh8T3boOHGjdGBTEm1a0bubBbB2GNNhlMOr4ZxezkHYtXf02JdBS/WyydmI/RMjXgtJA==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-select": "^12.0.0",
-        "rc-tree": "^4.0.0",
-        "rc-util": "^5.0.5"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/rc-trigger": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-5.2.3.tgz",
-      "integrity": "sha512-6Fokao07HUbqKIDkDRFEM0AGZvsvK0Fbp8A/KFgl1ngaqfO1nY037cISCG1Jm5fxImVsXp9awdkP7Vu5cxjjog==",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2",
-        "classnames": "^2.2.6",
-        "rc-align": "^4.0.0",
-        "rc-motion": "^2.0.0",
-        "rc-util": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-upload": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-4.2.0.tgz",
-      "integrity": "sha512-BXtvBs1PnwLjaUzBBU5z4yb9NMSaxc6mUIoPmS9LUAzaTz12L3TLrwu+8dnopYUiyLmYFS3LEO7aUfEWBqJfSA==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.5",
-        "rc-util": "^5.2.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-util": {
-      "version": "5.9.8",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.9.8.tgz",
-      "integrity": "sha512-typLSHYGf5irvGLYQshs0Ra3aze086h0FhzsAkyirMunYZ7b3Te8gKa5PVaanoHaZa9sS6qx98BxgysoRP+6Tw==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "react-is": "^16.12.0",
-        "shallowequal": "^1.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-virtual-list": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.2.6.tgz",
-      "integrity": "sha512-8FiQLDzm3c/tMX0d62SQtKDhLH7zFlSI6pWBAPt+TUntEqd3Lz9zFAmpvTu8gkvUom/HCsDSZs4wfV4wDPWC0Q==",
-      "dependencies": {
-        "classnames": "^2.2.6",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.0.7"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
     "node_modules/react": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
@@ -18173,14 +17446,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/scroll-into-view-if-needed": {
-      "version": "2.2.28",
-      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.28.tgz",
-      "integrity": "sha512-8LuxJSuFVc92+0AdNv4QOxRL4Abeo1DgLnGNkn1XlaujPH/3cCFz3QI60r2VNu4obJJROzgnIUw5TKQkZvZI1w==",
-      "dependencies": {
-        "compute-scroll-into-view": "^1.0.17"
-      }
-    },
     "node_modules/select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -18873,11 +18138,6 @@
       "engines": {
         "node": ">=0.6.19"
       }
-    },
-    "node_modules/string-convert": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
-      "integrity": "sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c="
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -19775,11 +19035,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/toggle-selection": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
-    },
     "node_modules/toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
@@ -20554,14 +19809,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "node_modules/watchpack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
@@ -21327,43 +20574,6 @@
     }
   },
   "dependencies": {
-    "@ant-design/colors": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-6.0.0.tgz",
-      "integrity": "sha512-qAZRvPzfdWHtfameEGP2Qvuf838NhergR35o+EuVyB5XvSA98xod5r4utvi4TJ3ywmevm290g9nsCG5MryrdWQ==",
-      "requires": {
-        "@ctrl/tinycolor": "^3.4.0"
-      }
-    },
-    "@ant-design/icons": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-4.6.2.tgz",
-      "integrity": "sha512-QsBG2BxBYU/rxr2eb8b2cZ4rPKAPBpzAR+0v6rrZLp/lnyvflLH3tw1vregK+M7aJauGWjIGNdFmUfpAOtw25A==",
-      "requires": {
-        "@ant-design/colors": "^6.0.0",
-        "@ant-design/icons-svg": "^4.0.0",
-        "@babel/runtime": "^7.11.2",
-        "classnames": "^2.2.6",
-        "rc-util": "^5.9.4"
-      }
-    },
-    "@ant-design/icons-svg": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.1.0.tgz",
-      "integrity": "sha512-Fi03PfuUqRs76aI3UWYpP864lkrfPo0hluwGqh7NJdLhvH4iRDc3jbJqZIvRDLHKbXrvAfPPV3+zjUccfFvWOQ=="
-    },
-    "@ant-design/react-slick": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-0.28.2.tgz",
-      "integrity": "sha512-nkrvXsO29pLToFaBb3MlJY4McaUFR4UHtXTz6A5HBzYmxH4SwKerX54mWdGc/6tKpHvS3vUwjEOt2T5XqZEo8Q==",
-      "requires": {
-        "@babel/runtime": "^7.10.4",
-        "classnames": "^2.2.5",
-        "json2mq": "^0.2.0",
-        "lodash": "^4.17.15",
-        "resize-observer-polyfill": "^1.5.0"
-      }
-    },
     "@babel/code-frame": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
@@ -22497,11 +21707,6 @@
       "resolved": "https://registry.npmjs.org/@csstools/sass-import-resolve/-/sass-import-resolve-1.0.0.tgz",
       "integrity": "sha512-pH4KCsbtBLLe7eqUrw8brcuFO8IZlN36JjdKlOublibVdAIPHCzEnpBWOVUXK5sCf+DpBi8ZtuWtjF0srybdeA==",
       "dev": true
-    },
-    "@ctrl/tinycolor": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.0.tgz",
-      "integrity": "sha512-JZButFdZ1+/xAfpguQHoabIXkcqRRKpMrWKBkpEZZyxfY9C1DpADFB8PEqGSTeFr135SaTRfKqGKx5xSCLI7ZQ=="
     },
     "@develar/schema-utils": {
       "version": "2.6.5",
@@ -24489,55 +23694,6 @@
         "color-convert": "^1.9.0"
       }
     },
-    "antd": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-4.15.0.tgz",
-      "integrity": "sha512-24HMixmQAhCyqb0ND5wX5DYRTbPactCT36mfVKowqgr77eT7XQ59Uu6aS513mbeiVhXcHrNlrlCKNZBSeEDgPg==",
-      "requires": {
-        "@ant-design/colors": "^6.0.0",
-        "@ant-design/icons": "^4.6.2",
-        "@ant-design/react-slick": "~0.28.1",
-        "@babel/runtime": "^7.12.5",
-        "array-tree-filter": "^2.1.0",
-        "classnames": "^2.2.6",
-        "copy-to-clipboard": "^3.2.0",
-        "lodash": "^4.17.20",
-        "moment": "^2.25.3",
-        "rc-cascader": "~1.4.0",
-        "rc-checkbox": "~2.3.0",
-        "rc-collapse": "~3.1.0",
-        "rc-dialog": "~8.5.1",
-        "rc-drawer": "~4.3.0",
-        "rc-dropdown": "~3.2.0",
-        "rc-field-form": "~1.20.0",
-        "rc-image": "~5.2.4",
-        "rc-input-number": "~7.0.1",
-        "rc-mentions": "~1.5.0",
-        "rc-menu": "~8.10.0",
-        "rc-motion": "^2.4.0",
-        "rc-notification": "~4.5.2",
-        "rc-pagination": "~3.1.6",
-        "rc-picker": "~2.5.10",
-        "rc-progress": "~3.1.0",
-        "rc-rate": "~2.9.0",
-        "rc-resize-observer": "^1.0.0",
-        "rc-select": "~12.1.6",
-        "rc-slider": "~9.7.1",
-        "rc-steps": "~4.1.0",
-        "rc-switch": "~3.2.0",
-        "rc-table": "~7.13.0",
-        "rc-tabs": "~11.7.0",
-        "rc-textarea": "~0.3.0",
-        "rc-tooltip": "~5.1.0",
-        "rc-tree": "~4.1.0",
-        "rc-tree-select": "~4.3.0",
-        "rc-trigger": "^5.2.1",
-        "rc-upload": "~4.2.0-alpha.0",
-        "rc-util": "^5.9.4",
-        "scroll-into-view-if-needed": "^2.2.25",
-        "warning": "^4.0.3"
-      }
-    },
     "anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -24709,11 +23865,6 @@
         "is-string": "^1.0.7"
       }
     },
-    "array-tree-filter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-tree-filter/-/array-tree-filter-2.1.0.tgz",
-      "integrity": "sha512-4ROwICNlNw/Hqa9v+rk5h22KjmzB1JGTMVKP2AKJBOCgb0yL0ASf0+YvCcLNNwquOHNX48jkeZIJ3a+oOQqKcw=="
-    },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -24772,11 +23923,6 @@
       "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
       "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
       "dev": true
-    },
-    "async-validator": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-3.5.1.tgz",
-      "integrity": "sha512-DDmKA7sdSAJtTVeNZHrnr2yojfFaoeW8MfQN8CeuXg8DDQHTqKk9Fdv38dSvnesHoO8MUwMI2HphOeSyIF+wmQ=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -25472,11 +24618,6 @@
       "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
       "dev": true
     },
-    "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
-    },
     "clean-css": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.2.2.tgz",
@@ -25688,11 +24829,6 @@
           "dev": true
         }
       }
-    },
-    "compute-scroll-into-view": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
-      "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -25915,14 +25051,6 @@
       "dev": true,
       "requires": {
         "is-what": "^3.12.0"
-      }
-    },
-    "copy-to-clipboard": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
-      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
-      "requires": {
-        "toggle-selection": "^1.0.6"
       }
     },
     "core-js": {
@@ -26277,18 +25405,13 @@
     "date-fns": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.19.0.tgz",
-      "integrity": "sha512-X3bf2iTPgCAQp9wvjOQytnf5vO5rESYRXlPIVcgSbtT5OTScPcsf9eZU+B/YIkKAtYr5WeCii58BgATrNitlWg=="
+      "integrity": "sha512-X3bf2iTPgCAQp9wvjOQytnf5vO5rESYRXlPIVcgSbtT5OTScPcsf9eZU+B/YIkKAtYr5WeCii58BgATrNitlWg==",
+      "dev": true
     },
     "dateformat": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-5.0.1.tgz",
       "integrity": "sha512-DrcKxOW2am3mtqoJwBTK3OlWcF0QSk1p8diEWwpu3Mf//VdURD7XVaeOV738JvcaBiFfm9o2fisoMhiJH0aYxg=="
-    },
-    "dayjs": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.3.tgz",
-      "integrity": "sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A==",
-      "peer": true
     },
     "debounce-fn": {
       "version": "4.0.0",
@@ -26638,11 +25761,6 @@
       "requires": {
         "esutils": "^2.0.2"
       }
-    },
-    "dom-align": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.0.tgz",
-      "integrity": "sha512-YkoezQuhp3SLFGdOlr5xkqZ640iXrnHAwVYcDg8ZKRUtO7mSzSC2BA5V0VuyAwPSJA4CLIc6EDDJh4bEsD2+zA=="
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -29573,14 +28691,6 @@
       "dev": true,
       "optional": true
     },
-    "json2mq": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
-      "integrity": "sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=",
-      "requires": {
-        "string-convert": "^0.2.0"
-      }
-    },
     "json5": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
@@ -30832,15 +29942,6 @@
         "tiny-warning": "^1.0.3"
       }
     },
-    "mini-store": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/mini-store/-/mini-store-3.0.6.tgz",
-      "integrity": "sha512-YzffKHbYsMQGUWQRKdsearR79QsMzzJcDDmZKlJBqt5JNkqpyJHYlK6gP61O36X+sLf76sO9G6mhKBe83gIZIQ==",
-      "requires": {
-        "hoist-non-react-statics": "^3.3.2",
-        "shallowequal": "^1.0.2"
-      }
-    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -30994,11 +30095,6 @@
       "resolved": "https://registry.npmjs.org/modern-normalize/-/modern-normalize-1.1.0.tgz",
       "integrity": "sha512-2lMlY1Yc1+CUy0gw4H95uNN7vjbpoED7NNRSBHE25nWfLBdmMzFCsPshlzbxHz+gYMcBEUN8V4pU16prcdPSgA==",
       "dev": true
-    },
-    "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "ms": {
       "version": "2.1.2",
@@ -33772,383 +32868,6 @@
         }
       }
     },
-    "rc-align": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.9.tgz",
-      "integrity": "sha512-myAM2R4qoB6LqBul0leaqY8gFaiECDJ3MtQDmzDo9xM9NRT/04TvWOYd2YHU9zvGzqk9QXF6S9/MifzSKDZeMw==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "dom-align": "^1.7.0",
-        "rc-util": "^5.3.0",
-        "resize-observer-polyfill": "^1.5.1"
-      }
-    },
-    "rc-cascader": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-1.4.2.tgz",
-      "integrity": "sha512-JVuLGrSi+3G8DZyPvlKlGVWJjhoi9NTz6REHIgRspa5WnznRkKGm2ejb0jJtz0m2IL8Q9BG4ZA2sXuqAu71ltQ==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "array-tree-filter": "^2.1.0",
-        "rc-trigger": "^5.0.4",
-        "rc-util": "^5.0.1",
-        "warning": "^4.0.1"
-      }
-    },
-    "rc-checkbox": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-2.3.2.tgz",
-      "integrity": "sha512-afVi1FYiGv1U0JlpNH/UaEXdh6WUJjcWokj/nUN2TgG80bfG+MDdbfHKlLcNNba94mbjy2/SXJ1HDgrOkXGAjg==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1"
-      }
-    },
-    "rc-collapse": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.1.0.tgz",
-      "integrity": "sha512-EwpNPJcLe7b+5JfyaxM9ZNnkCgqArt3QQO0Cr5p5plwz/C9h8liAmjYY5I4+hl9lAjBqb7ZwLu94+z+rt5g1WQ==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.3.4",
-        "rc-util": "^5.2.1",
-        "shallowequal": "^1.1.0"
-      }
-    },
-    "rc-dialog": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-8.5.2.tgz",
-      "integrity": "sha512-3n4taFcjqhTE9uNuzjB+nPDeqgRBTEGBfe46mb1e7r88DgDo0lL4NnxY/PZ6PJKd2tsCt+RrgF/+YeTvJ/Thsw==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.6",
-        "rc-motion": "^2.3.0",
-        "rc-util": "^5.6.1"
-      }
-    },
-    "rc-drawer": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-4.3.1.tgz",
-      "integrity": "sha512-GMfFy4maqxS9faYXEhQ+0cA1xtkddEQzraf6SAdzWbn444DrrLogwYPk1NXSpdXjLCLxgxOj9MYtyYG42JsfXg==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.6",
-        "rc-util": "^5.7.0"
-      }
-    },
-    "rc-dropdown": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-3.2.0.tgz",
-      "integrity": "sha512-j1HSw+/QqlhxyTEF6BArVZnTmezw2LnSmRk6I9W7BCqNCKaRwleRmMMs1PHbuaG8dKHVqP6e21RQ7vPBLVnnNw==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.6",
-        "rc-trigger": "^5.0.4"
-      }
-    },
-    "rc-field-form": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-1.20.0.tgz",
-      "integrity": "sha512-jkzsIfXR7ywEYdeAtktt1aLff88wxIPDLpq7KShHNl4wlsWrCE+TzkXBfjvVzYOVZt5GGrD8YDqNO/q6eaR/eA==",
-      "requires": {
-        "@babel/runtime": "^7.8.4",
-        "async-validator": "^3.0.3",
-        "rc-util": "^5.8.0"
-      }
-    },
-    "rc-image": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-5.2.4.tgz",
-      "integrity": "sha512-kWOjhZC1OoGKfvWqtDoO9r8WUNswBwnjcstI6rf7HMudz0usmbGvewcWqsOhyaBRJL9+I4eeG+xiAoxV1xi75Q==",
-      "requires": {
-        "@babel/runtime": "^7.11.2",
-        "classnames": "^2.2.6",
-        "rc-dialog": "~8.5.0",
-        "rc-util": "^5.0.6"
-      }
-    },
-    "rc-input-number": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-7.0.3.tgz",
-      "integrity": "sha512-y0nVqVANWyxQbm/vdhz1p5E1V5Y6Yd2+3MGKntSzCxrYgw0F7/COXkbRdcTECnXwiDv8ZrbYQ1pTP3u43PqE4Q==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.5",
-        "rc-util": "^5.0.1"
-      }
-    },
-    "rc-mentions": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-1.5.3.tgz",
-      "integrity": "sha512-NG/KB8YiKBCJPHHvr/QapAb4f9YzLJn7kDHtmI1K6t7ZMM5YgrjIxNNhoRKKP9zJvb9PdPts69Hbg4ZMvLVIFQ==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.6",
-        "rc-menu": "^8.0.1",
-        "rc-textarea": "^0.3.0",
-        "rc-trigger": "^5.0.4",
-        "rc-util": "^5.0.1"
-      }
-    },
-    "rc-menu": {
-      "version": "8.10.7",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-8.10.7.tgz",
-      "integrity": "sha512-m/ypV7OjkkUsMdutzMUxEI8tWyi0Y1TQ5YkSDk7k2uv2aCKkHYEoDKsDAfcPeejo3HMo2z5unWE+jD+dCphraw==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "mini-store": "^3.0.1",
-        "rc-motion": "^2.0.1",
-        "rc-trigger": "^5.1.2",
-        "rc-util": "^5.7.0",
-        "resize-observer-polyfill": "^1.5.0",
-        "shallowequal": "^1.1.0"
-      }
-    },
-    "rc-motion": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.4.1.tgz",
-      "integrity": "sha512-TWLvymfMu8SngPx5MDH8dQ0D2RYbluNTfam4hY/dNNx9RQ3WtGuZ/GXHi2ymLMzH+UNd6EEFYkOuR5JTTtm8Xg==",
-      "requires": {
-        "@babel/runtime": "^7.11.1",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.2.1"
-      }
-    },
-    "rc-notification": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-4.5.5.tgz",
-      "integrity": "sha512-YIfhTSw+h5GsSdgMnuMx24wqiPlg3FeamuOlkh9RkyHx+SeZVAKzQ0juy2NGvPEF2hDWi5xTqxUqLdo0L2AmGg==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.2.0",
-        "rc-util": "^5.0.1"
-      }
-    },
-    "rc-overflow": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.0.2.tgz",
-      "integrity": "sha512-GXj4DAyNxm4f57LvXLwhJaZoJHzSge2l2lQq64MZP7NJAfLpQqOLD+v9JMV9ONTvDPZe8kdzR+UMmkAn7qlzFA==",
-      "requires": {
-        "@babel/runtime": "^7.11.1",
-        "classnames": "^2.2.1",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.5.1"
-      }
-    },
-    "rc-pagination": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-3.1.6.tgz",
-      "integrity": "sha512-Pb2zJEt8uxXzYCWx/2qwsYZ3vSS9Eqdw0cJBli6C58/iYhmvutSBqrBJh51Z5UzYc5ZcW5CMeP5LbbKE1J3rpw==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1"
-      }
-    },
-    "rc-picker": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-2.5.10.tgz",
-      "integrity": "sha512-d2or2jql9SSY8CaRPybpbKkXBq3bZ6g88UKyWQZBLTCrc92Xm87RfRC/P3UEQo/CLmia3jVF7IXVi1HmNe2DZA==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1",
-        "date-fns": "^2.15.0",
-        "moment": "^2.24.0",
-        "rc-trigger": "^5.0.4",
-        "rc-util": "^5.4.0",
-        "shallowequal": "^1.1.0"
-      }
-    },
-    "rc-progress": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-3.1.3.tgz",
-      "integrity": "sha512-Jl4fzbBExHYMoC6HBPzel0a9VmhcSXx24LVt/mdhDM90MuzoMCJjXZAlhA0V0CJi+SKjMhfBoIQ6Lla1nD4QNw==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.6"
-      }
-    },
-    "rc-rate": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/rc-rate/-/rc-rate-2.9.1.tgz",
-      "integrity": "sha512-MmIU7FT8W4LYRRHJD1sgG366qKtSaKb67D0/vVvJYR0lrCuRrCiVQ5qhfT5ghVO4wuVIORGpZs7ZKaYu+KMUzA==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.5",
-        "rc-util": "^5.0.1"
-      }
-    },
-    "rc-resize-observer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.0.0.tgz",
-      "integrity": "sha512-RgKGukg1mlzyGdvzF7o/LGFC8AeoMH9aGzXTUdp6m+OApvmRdUuOscq/Y2O45cJA+rXt1ApWlpFoOIioXL3AGg==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.0.0",
-        "resize-observer-polyfill": "^1.5.1"
-      }
-    },
-    "rc-select": {
-      "version": "12.1.7",
-      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-12.1.7.tgz",
-      "integrity": "sha512-sLZlfp+U7Typ+jPM5gTi8I4/oJalRw8kyhxZZ9Q4mEfO2p+otd1Chmzhh+wPraBY3IwE0RZM2/x1Leg/kQKk/w==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.0.1",
-        "rc-overflow": "^1.0.0",
-        "rc-trigger": "^5.0.4",
-        "rc-util": "^5.0.1",
-        "rc-virtual-list": "^3.2.0"
-      }
-    },
-    "rc-slider": {
-      "version": "9.7.2",
-      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-9.7.2.tgz",
-      "integrity": "sha512-mVaLRpDo6otasBs6yVnG02ykI3K6hIrLTNfT5eyaqduFv95UODI9PDS6fWuVVehVpdS4ENgOSwsTjrPVun+k9g==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.5",
-        "rc-tooltip": "^5.0.1",
-        "rc-util": "^5.0.0",
-        "shallowequal": "^1.1.0"
-      }
-    },
-    "rc-steps": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-4.1.3.tgz",
-      "integrity": "sha512-GXrMfWQOhN3sVze3JnzNboHpQdNHcdFubOETUHyDpa/U3HEKBZC3xJ8XK4paBgF4OJ3bdUVLC+uBPc6dCxvDYA==",
-      "requires": {
-        "@babel/runtime": "^7.10.2",
-        "classnames": "^2.2.3",
-        "rc-util": "^5.0.1"
-      }
-    },
-    "rc-switch": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-3.2.2.tgz",
-      "integrity": "sha512-+gUJClsZZzvAHGy1vZfnwySxj+MjLlGRyXKXScrtCTcmiYNPzxDFOxdQ/3pK1Kt/0POvwJ/6ALOR8gwdXGhs+A==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.0.1"
-      }
-    },
-    "rc-table": {
-      "version": "7.13.3",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.13.3.tgz",
-      "integrity": "sha512-oP4fknjvKCZAaiDnvj+yzBaWcg+JYjkASbeWonU1BbrLcomkpKvMUgPODNEzg0QdXA9OGW0PO86h4goDSW06Kg==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.5",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.4.0",
-        "shallowequal": "^1.1.0"
-      }
-    },
-    "rc-tabs": {
-      "version": "11.7.3",
-      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-11.7.3.tgz",
-      "integrity": "sha512-5nd2NVss9TprPRV9r8N05SjQyAE7zDrLejxFLcbJ+BdLxSwnGnk3ws/Iq0smqKZUnPQC0XEvnpF3+zlllUUT2w==",
-      "requires": {
-        "@babel/runtime": "^7.11.2",
-        "classnames": "2.x",
-        "rc-dropdown": "^3.1.3",
-        "rc-menu": "^8.6.1",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.5.0"
-      }
-    },
-    "rc-textarea": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-0.3.4.tgz",
-      "integrity": "sha512-ILUYx831ZukQPv3m7R4RGRtVVWmL1LV4ME03L22mvT56US0DGCJJaRTHs4vmpcSjFHItph5OTmhodY4BOwy81A==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.7.0"
-      }
-    },
-    "rc-tooltip": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-5.1.0.tgz",
-      "integrity": "sha512-pFqD1JZwNIpbdcefB7k5xREoHAWM/k3yQwYF0iminbmDXERgq4rvBfUwIvlCqqZSM7HDr9hYeYr6ZsVNaKtvCQ==",
-      "requires": {
-        "@babel/runtime": "^7.11.2",
-        "rc-trigger": "^5.0.0"
-      }
-    },
-    "rc-tree": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-4.1.5.tgz",
-      "integrity": "sha512-q2vjcmnBDylGZ9/ZW4F9oZMKMJdbFWC7um+DAQhZG1nqyg1iwoowbBggUDUaUOEryJP+08bpliEAYnzJXbI5xQ==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.0.1",
-        "rc-util": "^5.0.0",
-        "rc-virtual-list": "^3.0.1"
-      }
-    },
-    "rc-tree-select": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-4.3.1.tgz",
-      "integrity": "sha512-OeV8u5kBEJ8MbatP04Rh8T3boOHGjdGBTEm1a0bubBbB2GNNhlMOr4ZxezkHYtXf02JdBS/WyydmI/RMjXgtJA==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-select": "^12.0.0",
-        "rc-tree": "^4.0.0",
-        "rc-util": "^5.0.5"
-      }
-    },
-    "rc-trigger": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-5.2.3.tgz",
-      "integrity": "sha512-6Fokao07HUbqKIDkDRFEM0AGZvsvK0Fbp8A/KFgl1ngaqfO1nY037cISCG1Jm5fxImVsXp9awdkP7Vu5cxjjog==",
-      "requires": {
-        "@babel/runtime": "^7.11.2",
-        "classnames": "^2.2.6",
-        "rc-align": "^4.0.0",
-        "rc-motion": "^2.0.0",
-        "rc-util": "^5.5.0"
-      }
-    },
-    "rc-upload": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-4.2.0.tgz",
-      "integrity": "sha512-BXtvBs1PnwLjaUzBBU5z4yb9NMSaxc6mUIoPmS9LUAzaTz12L3TLrwu+8dnopYUiyLmYFS3LEO7aUfEWBqJfSA==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.5",
-        "rc-util": "^5.2.0"
-      }
-    },
-    "rc-util": {
-      "version": "5.9.8",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.9.8.tgz",
-      "integrity": "sha512-typLSHYGf5irvGLYQshs0Ra3aze086h0FhzsAkyirMunYZ7b3Te8gKa5PVaanoHaZa9sS6qx98BxgysoRP+6Tw==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "react-is": "^16.12.0",
-        "shallowequal": "^1.1.0"
-      }
-    },
-    "rc-virtual-list": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.2.6.tgz",
-      "integrity": "sha512-8FiQLDzm3c/tMX0d62SQtKDhLH7zFlSI6pWBAPt+TUntEqd3Lz9zFAmpvTu8gkvUom/HCsDSZs4wfV4wDPWC0Q==",
-      "requires": {
-        "classnames": "^2.2.6",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.0.7"
-      }
-    },
     "react": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
@@ -35060,14 +33779,6 @@
         "ajv-keywords": "^3.5.2"
       }
     },
-    "scroll-into-view-if-needed": {
-      "version": "2.2.28",
-      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.28.tgz",
-      "integrity": "sha512-8LuxJSuFVc92+0AdNv4QOxRL4Abeo1DgLnGNkn1XlaujPH/3cCFz3QI60r2VNu4obJJROzgnIUw5TKQkZvZI1w==",
-      "requires": {
-        "compute-scroll-into-view": "^1.0.17"
-      }
-    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -35656,11 +34367,6 @@
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
       "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
       "dev": true
-    },
-    "string-convert": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
-      "integrity": "sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c="
     },
     "string-width": {
       "version": "4.2.3",
@@ -36336,11 +35042,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "toggle-selection": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
-    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
@@ -36895,14 +35596,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
       "integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ=="
-    },
-    "warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
     },
     "watchpack": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "webpack-dev-server": "^4.4.0"
   },
   "dependencies": {
-    "@ant-design/icons": "^4.4.0",
     "@flybywiresim/fragmenter": "^0.7.4",
     "@flybywiresim/react-components": "^0.2.5",
     "@reduxjs/toolkit": "^1.7.1",
@@ -117,7 +116,6 @@
     "@types/js-yaml": "^4.0.5",
     "@types/winreg": "^1.2.31",
     "@types/ws": "^8.5.3",
-    "antd": "^4.12.2",
     "check-disk-space": "^3.3.1",
     "config-ini-parser": "~1.5.9",
     "dateformat": "^5.0.1",

--- a/src/renderer/components/AddonSection/Configure/TrackSelector.tsx
+++ b/src/renderer/components/AddonSection/Configure/TrackSelector.tsx
@@ -34,7 +34,7 @@ export const Track: React.FC<TrackProps> = ({ isSelected, isInstalled, handleSel
             <div className={`w-1 h-12 rounded-r-xl transition-all duration-200 transform ${isSelected ? 'scale-y-100' : 'scale-y-50'}`}/>
             <div className="flex flex-col px-3 py-2.5">
                 <span className="text-xl text-current">{track.name}</span>
-                <span className="text-3xl font-manrope font-medium text-current mt-0.5">{latestVersionName}</span>
+                <span className="text-3xl font-manrope font-medium text-current tracking-wider mt-0.5">{latestVersionName}</span>
             </div>
             {isInstalled && (
                 <Check className={`absolute right-4 text-cyan stroke-current`} strokeWidth={3}/>

--- a/src/renderer/components/AddonSection/ReleaseNotes/index.tsx
+++ b/src/renderer/components/AddonSection/ReleaseNotes/index.tsx
@@ -30,15 +30,13 @@ const ReleaseNoteCard = forwardRef<HTMLDivElement, ReleaseNoteCardProps>(({ rele
     return (
         <div ref={ref} className="border-2 border-navy-light p-7 rounded-lg">
             <div className="flex flex-row items-center justify-between mb-3.5">
-                <div className="flex flex-row items-center  gap-x-4">
-                    <h1 className="text-4xl text-white font-semibold mb-0">{release.name}</h1>
+                <div className="flex flex-row items-center gap-x-4">
+                    <h1 className="text-4xl text-white font-semibold m-0 p-0">{release.name}</h1>
                     {isLatest && (
-                        <div className="text-cyan bg-cyan bg-opacity-20 font-semibold rounded-full px-6">
-                        Latest
-                        </div>
+                        <div className="text-2xl text-cyan mt-1 bg-cyan bg-opacity-20 font-semibold rounded-full px-6">Latest</div>
                     )}
                 </div>
-                <div className="text-white">
+                <div className="text-2xl text-white">
                     {dateFormat(new Date(release.publishedAt), dateLayout)}
                 </div>
             </div>
@@ -147,7 +145,7 @@ export const ReleaseNotes = ({ addon }: {addon: Addon}): JSX.Element => {
 
                     <h2 className="text-white">Stable Version</h2>
                 </div>
-                { releaseComponent ?? <DummyComponent/> }
+                {releaseComponent ?? <DummyComponent />}
             </div>
         </div>
     );

--- a/src/renderer/components/App/index.tsx
+++ b/src/renderer/components/App/index.tsx
@@ -140,7 +140,7 @@ const App = () => {
                                 <Logo />
 
                                 {(process.env.NODE_ENV === 'development') && (
-                                    <div className="flex gap-x-4 ml-32 my-auto text-xl text-gray-400">
+                                    <div className="flex gap-x-4 ml-32 my-auto text-2xl text-gray-400">
                                         <pre>{packageInfo.version}</pre>
                                         <pre className="text-gray-500">|</pre>
                                         <pre className="text-utility-amber">Development mode</pre>

--- a/src/renderer/components/App/index.tsx
+++ b/src/renderer/components/App/index.tsx
@@ -119,7 +119,7 @@ const App = () => {
             showDevURL = configUrl;
         }
         return (configUrl !== productionURL) && (
-            <div className="flex gap-x-4 ml-32 my-auto text-gray-400">
+            <div className="flex gap-x-4 ml-32 my-auto text-2xl text-gray-400">
                 <pre className="text-utility-amber">Developer Configuration Used: </pre>
                 <pre className="text-quasi-white">{showDevURL}</pre>
             </div>
@@ -140,7 +140,7 @@ const App = () => {
                                 <Logo />
 
                                 {(process.env.NODE_ENV === 'development') && (
-                                    <div className="flex gap-x-4 ml-32 my-auto text-gray-400">
+                                    <div className="flex gap-x-4 ml-32 my-auto text-xl text-gray-400">
                                         <pre>{packageInfo.version}</pre>
                                         <pre className="text-gray-500">|</pre>
                                         <pre className="text-utility-amber">Development mode</pre>

--- a/src/renderer/components/ErrorModal/index.tsx
+++ b/src/renderer/components/ErrorModal/index.tsx
@@ -4,8 +4,6 @@ import settings from "common/settings";
 import { Directories } from "renderer/utils/Directories";
 import * as fs from "fs";
 import { Button, ButtonType } from "renderer/components/Button";
-import { ipcRenderer } from "electron";
-import channels from "common/channels";
 
 export const ErrorModal = (): JSX.Element => {
     const [communityError, setCommunityError] = useState<boolean>(!fs.existsSync(Directories.installLocation()) || Directories.installLocation() === 'C:\\');

--- a/src/renderer/components/ErrorModal/index.tsx
+++ b/src/renderer/components/ErrorModal/index.tsx
@@ -3,6 +3,9 @@ import { setupInstallPath } from 'renderer/actions/install-path.utils';
 import settings from "common/settings";
 import { Directories } from "renderer/utils/Directories";
 import * as fs from "fs";
+import { Button, ButtonType } from "renderer/components/Button";
+import { ipcRenderer } from "electron";
+import channels from "common/channels";
 
 export const ErrorModal = (): JSX.Element => {
     const [communityError, setCommunityError] = useState<boolean>(!fs.existsSync(Directories.installLocation()) || Directories.installLocation() === 'C:\\');
@@ -29,7 +32,10 @@ export const ErrorModal = (): JSX.Element => {
                 <>
                     <span className="w-3/5 text-center text-2xl">Seems like you're using Linux</span>
                     <span className="w-3/5 text-center text-2xl">We're unable to autodetect your install currently. Please set the correct location before we can continue.</span>
-                    <button className="bg-navy-lightest hover:bg-navy-lighter px-5 py-2 text-lg font-semibold rounded-lg" onClick={handleSelectPath}>Select</button>
+
+                    <Button type={ButtonType.Neutral} onClick={handleSelectPath}>
+                        Select
+                    </Button>
                 </>
             );
         }
@@ -39,7 +45,10 @@ export const ErrorModal = (): JSX.Element => {
                     <span className="w-3/5 text-center text-2xl">Your Community folder is set to</span>
                     <pre className="w-3/5 bg-gray-700 text-2xl text-center font-mono px-6 py-2.5 mb-0 rounded-lg">{Directories.installLocation()}</pre>
                     <span className="w-3/5 text-center text-2xl">but we couldn't find it there. Please set the correct location before we can continue.</span>
-                    <button className="bg-navy-lightest hover:bg-navy-lighter px-5 py-2 text-lg font-semibold rounded-lg" onClick={handleSelectPath}>Select</button>
+
+                    <Button type={ButtonType.Neutral} onClick={handleSelectPath}>
+                        Select
+                    </Button>
                 </>
             );
         }

--- a/src/renderer/components/LocalApiConfigEditUI/index.tsx
+++ b/src/renderer/components/LocalApiConfigEditUI/index.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useEffect, useState } from 'react';
 import * as print from 'pdf-to-printer';
 import { PromptModal, useModals } from '../Modal';
-import { ButtonType } from '../Button';
+import { Button, ButtonType } from '../Button';
 import fs from 'fs';
 import path from 'path';
 import { Directories } from 'renderer/utils/Directories';
@@ -131,30 +131,15 @@ export const LocalApiConfigEditUI: FC = () => {
 
                 <div className='flex flex-row space-x-4'>
                     {changesBeenMade && (
-                        <button
-                            className='flex items-center justify-center px-8 py-2 border-2 border-utility-red rounded-md transition duration-100 bg-utility-red hover:bg-navy text-white'
-                            onClick={handleDiscard}
-                        >
-                            Discard
-                        </button>
+                        <Button className="h-16" type={ButtonType.Danger} onClick={handleDiscard}>Discard</Button>
                     )}
 
                     {!isDefaultConfig && (
-                        <button
-                            className='flex items-center justify-center px-8 py-2 border-2 border-utility-red rounded-md transition duration-100 bg-utility-red hover:bg-navy text-white'
-                            onClick={handleReset}
-                        >
-                            Reset
-                        </button>
+                        <Button className="h-16" type={ButtonType.Danger} onClick={handleReset}>Reset</Button>
                     )}
 
                     {changesBeenMade && (
-                        <button
-                            className='flex items-center justify-center px-16 py-2 border-2 border-utility-green rounded-md transition duration-100 bg-utility-green hover:bg-navy text-white'
-                            onClick={handleConfigSave}
-                        >
-                            Save
-                        </button>
+                        <Button className="h-16" type={ButtonType.Positive} onClick={handleConfigSave}>Save</Button>
                     )}
                 </div>
             </div>
@@ -164,8 +149,7 @@ export const LocalApiConfigEditUI: FC = () => {
                     <h3 className='text-white mb-0'>Server</h3>
 
                     <div className='divide-y divide-gray-600'>
-                        <div className='flex flex-row items-center justify-between text-white py-4'>
-                            <p>Port</p>
+                        <SimBridgeSettingItem name="Port">
                             <input className="text-center" value={config.server.port} type="number" onChange={event => setConfig(old => ({
                                 ...old,
                                 server: {
@@ -174,15 +158,14 @@ export const LocalApiConfigEditUI: FC = () => {
                                 },
                             }))}
                             />
-                        </div>
+                        </SimBridgeSettingItem>
                     </div>
                 </div>
                 <div>
                     <h3 className='text-white mb-0'>Printer</h3>
 
                     <div className='divide-y divide-gray-600'>
-                        <div className='flex flex-row items-center justify-between text-white py-4'>
-                            <p>Enabled</p>
+                        <SimBridgeSettingItem name="Enabled">
                             <Toggle value={config.printer.enabled} onToggle={value => setConfig(old => ({
                                 ...old,
                                 printer: {
@@ -190,9 +173,9 @@ export const LocalApiConfigEditUI: FC = () => {
                                     enabled: value,
                                 },
                             }))} />
-                        </div>
-                        <div className='flex flex-row items-center justify-between text-white py-4'>
-                            <p>Printer Name</p>
+                        </SimBridgeSettingItem>
+
+                        <SimBridgeSettingItem name="Printer Name">
                             <select
                                 value={config.printer.printerName ?? ''}
                                 onChange={event => setConfig(old => ({
@@ -202,17 +185,17 @@ export const LocalApiConfigEditUI: FC = () => {
                                         printerName: event.target.value ? event.target.value : null,
                                     },
                                 }))}
-                                className="text-base text-white w-auto px-3.5 py-2.5 rounded-md outline-none bg-navy-light border-2 border-navy cursor-pointer"
+                                className="text-xl text-white w-auto px-3.5 py-2.5 rounded-md outline-none bg-navy-light border-2 border-navy cursor-pointer"
                             >
                                 <option value=''>None</option>
                                 {printers.map(p => (
                                     <option key={p.name} value={p.name}>{p.name}</option>
                                 ))}
                             </select>
-                        </div>
-                        <div className='flex flex-row items-center justify-between text-white py-4'>
-                            <p>Font Size</p>
-                            <input className="text-center" value={config.printer.fontSize} type="number" onChange={event => setConfig(old => ({
+                        </SimBridgeSettingItem>
+
+                        <SimBridgeSettingItem name="Font Size">
+                            <input className="text-xl text-center" value={config.printer.fontSize} type="number" onChange={event => setConfig(old => ({
                                 ...old,
                                 printer: {
                                     ...old.printer,
@@ -220,10 +203,10 @@ export const LocalApiConfigEditUI: FC = () => {
                                 },
                             }))}
                             />
-                        </div>
-                        <div className='flex flex-row items-center justify-between text-white py-4'>
-                            <p>Paper Size</p>
-                            <input className="text-center" value={config.printer.paperSize} onChange={event => setConfig(old => ({
+                        </SimBridgeSettingItem>
+
+                        <SimBridgeSettingItem name="Paper Size">
+                            <input className="text-xl text-center" value={config.printer.paperSize} onChange={event => setConfig(old => ({
                                 ...old,
                                 printer: {
                                     ...old.printer,
@@ -231,10 +214,10 @@ export const LocalApiConfigEditUI: FC = () => {
                                 },
                             }))}
                             />
-                        </div>
-                        <div className='flex flex-row items-center justify-between text-white py-4'>
-                            <p>Margin</p>
-                            <input className="text-center" value={config.printer.margin} type="number" onChange={event => setConfig(old => ({
+                        </SimBridgeSettingItem>
+
+                        <SimBridgeSettingItem name="Margin">
+                            <input className="text-xl text-center" value={config.printer.margin} type="number" onChange={event => setConfig(old => ({
                                 ...old,
                                 printer: {
                                     ...old.printer,
@@ -242,10 +225,24 @@ export const LocalApiConfigEditUI: FC = () => {
                                 },
                             }))}
                             />
-                        </div>
+                        </SimBridgeSettingItem>
                     </div>
                 </div>
             </div>
+        </div>
+    );
+};
+
+interface SimBridgeSettingItemProps {
+    name: string,
+}
+
+const SimBridgeSettingItem: React.FC<SimBridgeSettingItemProps> = ({ name, children }) => {
+    return (
+        <div className='flex flex-row items-center justify-between text-xl text-white py-4'>
+            <p className="m-0 p-0">{name}</p>
+
+            {children}
         </div>
     );
 };

--- a/src/renderer/components/Modal/ErrorDialog.tsx
+++ b/src/renderer/components/Modal/ErrorDialog.tsx
@@ -66,7 +66,7 @@ export const ErrorDialog: FC<ErrorDialogProps> = ({ error, onAcknowledge }) => {
 
                         {errorVisualisation}
 
-                        <pre className="h-96 bg-gray-800 p-2.5 rounded-md">{error.stack}</pre>
+                        <pre className="h-96 text-2xl bg-gray-800 p-2.5 rounded-md overflow-scroll">{error.stack}</pre>
                     </div>
 
                     <div className="flex flex-col">

--- a/src/renderer/components/Modal/index.tsx
+++ b/src/renderer/components/Modal/index.tsx
@@ -192,15 +192,7 @@ export const AlertModal: FC<AlertModalProps> = ({
                 bodyText
             )}
 
-            {dontShowAgainSettingName ? <div className="w-auto space-x-4 mt-8">
-                <input
-                    type="checkbox"
-                    checked={checkMark}
-                    onChange={() => setCheckMark(!checkMark)}
-                    className=" w-4 h-4 rounded-sm checked:bg-blue-600 checked:border-transparent"
-                />
-                <span className="ml-2">Don't show me this again</span>
-            </div> : <div></div>}
+            {dontShowAgainSettingName && <DoNotAskAgain checked={checkMark} toggleChecked={() => setCheckMark((old) => !old)} />}
 
             <div className="flex flex-row mt-8 gap-x-4">
                 <Button className="flex-grow" type={acknowledgeColor} onClick={handleAcknowledge}>

--- a/src/renderer/components/Modal/index.tsx
+++ b/src/renderer/components/Modal/index.tsx
@@ -244,7 +244,7 @@ export const ChangelogModal: React.FC = () => {
             <div className="mt-4 h-96 overflow-y-scroll">
                 {(changelog as ChangelogType).releases.map((release) => <div className="mb-6">
                     <div className="text-4xl font-bold mb-2">{release.name}</div>
-                    {release.changes.map((change) => <div className="mb-4 flex">
+                    {release.changes.map((change) => <div className="mb-4 flex text-2xl">
                         <div className="w-7">
                             <Dot className="" size={20} strokeWidth={1}/>
                         </div>

--- a/src/renderer/components/SettingsSection/Developer.tsx
+++ b/src/renderer/components/SettingsSection/Developer.tsx
@@ -35,7 +35,7 @@ const index = (): JSX.Element => {
                     <SettingsItem name="Configuration Download URL">
                         <div className='flex flex-row items-center justify-between text-white py-4'>
                             <input
-                                className={`text-right ${configDownloadUrlValid ? 'text-green-500' : 'text-red-500'}`}
+                                className={` text-xl text-right ${configDownloadUrlValid ? 'text-green-500' : 'text-red-500'}`}
                                 value={configDownloadUrl}
                                 type="url"
                                 onChange={(event) => setConfigDownloadUrl(event.target.value)}

--- a/src/renderer/components/SettingsSection/Download.tsx
+++ b/src/renderer/components/SettingsSection/Download.tsx
@@ -16,9 +16,14 @@ interface SettingItemProps<T> {
     setValue: (value: T) => void;
 }
 
-const MsfsCommunityPathSettingItem = ({ value, setValue }: SettingItemProps<string>): JSX.Element => {
+interface PathSettingItemProps extends SettingItemProps<string> {
+    name: string,
+    callback: () => Promise<string>;
+}
+
+const PathSettingItem: React.FC<PathSettingItemProps> = ({ value, setValue, name, callback }) => {
     const handleClick = async () => {
-        const path = await setupMsfsCommunityPath();
+        const path = await callback();
 
         if (path) {
             setValue(path);
@@ -26,27 +31,21 @@ const MsfsCommunityPathSettingItem = ({ value, setValue }: SettingItemProps<stri
     };
 
     return (
-        <SettingsItem name="MSFS Community Directory">
-            <div className="text-white hover:text-gray-400 cursor-pointer underline transition duration-200" onClick={handleClick}>{value}</div>
+        <SettingsItem name={name}>
+            <div className="text-xl text-white hover:text-gray-400 cursor-pointer underline transition duration-200" onClick={handleClick}>{value}</div>
         </SettingsItem>
     );
 };
 
-const InstallPathSettingItem = ({ value, setValue }: SettingItemProps<string>): JSX.Element => {
-    const handleClick = async () => {
-        const path = await setupInstallPath();
-
-        if (path) {
-            setValue(path);
-        }
-    };
-
-    return (
-        <SettingsItem name="Install Directory">
-            <div className="text-white hover:text-gray-400 cursor-pointer underline transition duration-200" onClick={handleClick}>{value}</div>
-        </SettingsItem>
+const MsfsCommunityPathSettingItem = ({ value, setValue }: SettingItemProps<string>): JSX.Element =>
+    (
+        <PathSettingItem value={value} setValue={setValue} name="MSFS Community Directory" callback={setupMsfsCommunityPath} />
     );
-};
+
+const InstallPathSettingItem = ({ value, setValue }: SettingItemProps<string>): JSX.Element =>
+    (
+        <PathSettingItem value={value} setValue={setValue} name="Install Directory" callback={setupInstallPath}/>
+    );
 
 const TempLocationSettingItem = ({ value, setValue }: SettingItemProps<string>): JSX.Element => {
     const handleClick = async () => {

--- a/src/renderer/components/SettingsSection/Download.tsx
+++ b/src/renderer/components/SettingsSection/Download.tsx
@@ -47,21 +47,10 @@ const InstallPathSettingItem = ({ value, setValue }: SettingItemProps<string>): 
         <PathSettingItem value={value} setValue={setValue} name="Install Directory" callback={setupInstallPath}/>
     );
 
-const TempLocationSettingItem = ({ value, setValue }: SettingItemProps<string>): JSX.Element => {
-    const handleClick = async () => {
-        const path = await setupTempLocation();
-
-        if (path) {
-            setValue(path);
-        }
-    };
-
-    return (
-        <SettingsItem name="Location for temporary folders">
-            <div className="text-white hover:text-gray-400 cursor-pointer underline transition duration-200" onClick={handleClick}>{value}</div>
-        </SettingsItem>
+const TempLocationSettingItem = ({ value, setValue }: SettingItemProps<string>): JSX.Element =>
+    (
+        <PathSettingItem value={value} setValue={setValue} name="Location for temporary folders" callback={setupTempLocation}/>
     );
-};
 
 const SeparateTempLocationSettingItem = ({ value, setValue }: SettingItemProps<boolean>) => {
     const handleClick = () => {

--- a/src/renderer/components/SettingsSection/General.tsx
+++ b/src/renderer/components/SettingsSection/General.tsx
@@ -46,7 +46,7 @@ const DateLayoutItem = ({ value, setValue }: SettingItemProps<string>) => {
                 value={value}
                 onChange={event => handleSelect(event.currentTarget.value)}
                 name="Date Layout"
-                className="text-base text-white w-60 px-3.5 py-2.5 rounded-md outline-none bg-navy-light border-2 border-navy rounded-md cursor-pointer"
+                className="text-xl text-white w-60 px-3.5 py-2.5 rounded-md outline-none bg-navy-light border-2 border-navy rounded-md cursor-pointer"
             >
                 <option value={'yyyy/mm/dd'}>YYYY/MM/DD</option>
                 <option value={'mm/dd/yyyy'}>MM/DD/YYYY</option>

--- a/src/renderer/components/Toggle.tsx
+++ b/src/renderer/components/Toggle.tsx
@@ -9,7 +9,7 @@ interface ToggleProps {
 }
 
 export const Toggle: FC<ToggleProps> = ({ value, onToggle, scale = 1, bgColor = 'bg-navy-light', onColor = 'bg-cyan-medium' }) => (
-    <div className={`flex items-center w-14 h-8 rounded-full cursor-pointer ${bgColor}`} onClick={() => onToggle(!value)} style={{ transform: `scale(${scale})` }}>
-        <div className={`w-6 h-6 bg-gray-400 rounded-full transition mx-1.5 duration-200 transform ${value && `${onColor}`}`} style={{ transform: `translate(${value ? '12px' : '0'}, -0.5px)` }} />
+    <div className={`flex text-3xl items-center w-14 h-8 rounded-full cursor-pointer ${bgColor}`} onClick={() => onToggle(!value)} style={{ transform: `scale(${scale})` }}>
+        <div className={`w-6 h-6 bg-gray-400 rounded-full transition mx-1.5 duration-200 transform ${value && `${onColor}`}`} style={{ transform: `translate(${value ? '12px' : '1px'}, 0)` }} />
     </div>
 );

--- a/src/renderer/components/WindowActionButtons/index.tsx
+++ b/src/renderer/components/WindowActionButtons/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { ExclamationCircleOutlined } from '@ant-design/icons';
 import { shell } from 'electron';
 import { ipcRenderer } from 'electron';
 import { WindowsControl } from 'react-windows-controls';
@@ -8,6 +7,7 @@ import { Directories } from 'renderer/utils/Directories';
 import { store } from "renderer/redux/store";
 import { InstallStatusCategories } from "renderer/components/AddonSection/Enums";
 import { AlertModal, useModals } from "renderer/components/Modal";
+import { ExclamationCircle } from 'react-bootstrap-icons';
 
 export type ButtonProps = { id?: string, className?: string, onClick?: () => void, isClose?: boolean }
 
@@ -53,7 +53,7 @@ export const WindowButtons: React.FC = () => {
 
     return (
         <div className="h-12 flex flex-row ml-auto">
-            <Button onClick={openGithub}><ExclamationCircleOutlined /></Button>
+            <Button onClick={openGithub}><ExclamationCircle size={16} /></Button>
             <WindowsControl minimize whiteIcon onClick={handleMinimize} />
             <WindowsControl maximize whiteIcon onClick={handleMaximize} />
             <WindowsControl close whiteIcon onClick={handleClose} />

--- a/src/renderer/fbw.scss
+++ b/src/renderer/fbw.scss
@@ -49,7 +49,7 @@
 }
 
 .button {
-    @apply text-2xl text-quasi-white font-inter font-bold px-5 py-2.5 border-2 rounded-md transition-colors duration-150;
+    @apply text-3xl text-quasi-white font-inter font-bold px-5 py-2.5 border-2 rounded-md transition-colors duration-150;
 
     height: 2.35em;
 

--- a/src/renderer/fbw.scss
+++ b/src/renderer/fbw.scss
@@ -49,7 +49,7 @@
 }
 
 .button {
-    @apply text-3xl text-quasi-white font-inter font-bold px-5 py-2.5 border-2 rounded-md transition-colors duration-150;
+    @apply text-3xl text-quasi-white font-inter font-bold px-5 border-2 rounded-md transition-colors duration-150;
 
     height: 2.35em;
 

--- a/src/renderer/fbw.scss
+++ b/src/renderer/fbw.scss
@@ -49,9 +49,8 @@
 }
 
 .button {
-    @apply text-quasi-white font-inter font-bold px-5 py-2.5 border-2 rounded-md transition-colors duration-150;
+    @apply text-2xl text-quasi-white font-inter font-bold px-5 py-2.5 border-2 rounded-md transition-colors duration-150;
 
-    font-size: 1.25em;
     height: 2.35em;
 
     @mixin color($background, $textColorHover: true, $borderColorHoverValue: $background) {

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -44,7 +44,6 @@ import { ModalProvider } from "renderer/components/Modal";
 import { setSentrySessionID } from "renderer/redux/features/sentrySessionID";
 import packageJson from '../../package.json';
 
-import 'antd/dist/antd.less';
 import 'simplebar/dist/simplebar.min.css';
 import './index.scss';
 

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -46,6 +46,7 @@ import packageJson from '../../package.json';
 
 import 'simplebar/dist/simplebar.min.css';
 import './index.scss';
+import { Button, ButtonType } from "renderer/components/Button";
 
 // Setup Sentry
 Sentry.init({
@@ -71,6 +72,8 @@ ipcRenderer.invoke(channels.sentry.requestSessionID).then((sessionID) => {
 
 // Obtain configuration and use it
 InstallerConfiguration.obtain().then((config: Configuration) => {
+    throw new Error('a'.repeat(255));
+
     store.dispatch(setConfiguration({ configuration: config }));
 
     for (const publisher of config.publishers) {
@@ -117,8 +120,11 @@ InstallerConfiguration.obtain().then((config: Configuration) => {
         <div className="h-screen flex flex-col gap-y-5 justify-center items-center bg-navy text-gray-100">
             <span className="text-5xl font-semibold">Something went very wrong.</span>
             <span className="w-3/5 text-center text-2xl">We could not configure your installer. Please seek support on the Discord #support channel or on GitHub and provide a screenshot of the following information:</span>
-            <pre className="w-3/5 bg-gray-700 text-2xl font-mono px-6 py-2.5 mb-0 rounded-lg">{error.stack}</pre>
-            <button className="bg-navy-lightest hover:bg-navy-lighter px-5 py-2 text-lg font-semibold rounded-lg" onClick={() => ipcRenderer.send(channels.window.close)}>Close the Installer</button>
+            <pre className="w-3/5 bg-gray-700 text-2xl font-mono px-6 py-2.5 mb-0 rounded-lg overflow-scroll">{error.stack}</pre>
+
+            <Button type={ButtonType.Neutral} onClick={() => ipcRenderer.send(channels.window.close)}>
+                Close the installer
+            </Button>
         </div>,
         document.getElementById('root'),
     );

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -72,8 +72,6 @@ ipcRenderer.invoke(channels.sentry.requestSessionID).then((sessionID) => {
 
 // Obtain configuration and use it
 InstallerConfiguration.obtain().then((config: Configuration) => {
-    throw new Error('a'.repeat(255));
-
     store.dispatch(setConfiguration({ configuration: config }));
 
     for (const publisher of config.publishers) {


### PR DESCRIPTION
## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

- Removed `antd` and `@ant-design/icons` and their remaining usages, to save about 8MB on the final exe size and be able to upload to CF again
- Fixes a potential leak with update state callbacks, clean up update state keeping

