### PR TITLE
build: add dev start script with electron-vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "generate-licenses": "node scripts/licenses.js",
     "start": "electron-vite",
+    "dev": "electron-vite dev",
     "build": "npm run generate-licenses && electron-vite build",
     "package": "npm run build && electron-builder --win --publish=never",
     "lint": "eslint --ext .ts,.tsx .",


### PR DESCRIPTION
## Summary of Changes
Since refactor: move to electron-vite for build, clean up CI (https://github.com/flybywiresim/installer/pull/462)
dev run script is no longer avalaible, 

this adds a script to run ``electron-vite dev`` and complies with current README instructions