### PR TITLE
fix: excludes "ambitiouspilots-toolbar-pushback" from the Incompatible Add-ons

### DIFF
--- a/src/renderer/data.ts
+++ b/src/renderer/data.ts
@@ -192,12 +192,6 @@ export const defaultConfiguration: Configuration = {
                 'It is required to remove this add-on before installing and using the A32NX. This add-on overrides A32NX components and renders the A32NX unusable.',
             },
             {
-              title: 'Toolbar Pushback',
-              creator: 'AmbitiousPilots',
-              description:
-                'This add-on sometimes causes performance issues and also sometimes prevents the A32NX from taxiing. Consider removing it if you experience these issues.',
-            },
-            {
               title: 'Asobo_A320_A (A32NX Converted)',
               creator: 'UnitDeath',
               description:


### PR DESCRIPTION
Removed "ambitiouspilots-toolbar-pushback" from the Incompatible Add-ons list.

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
The "ambitiouspilots-toolbar-pushback" add-on will no longer trigger the "Incompatible Add-ons!" pop-up in the installer when updating the A32NX.
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
Removed "ambitiouspilots-toolbar-pushback" from the Incompatible Add-ons list.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## Additional context
<!-- Add any other context about the pull request here. -->
The toolbar pushback add-on still triggered the "Incompatible Add-ons!" pop-up in the installer when updating the A32NX, even though the issues caused by this add-on have been fixed a long time ago (according to some of the developers).
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): batata7elwe
