### PR TITLE
feat: Add a "Reset to default" button for the Configuration Download URL (DeveloperSettings)

### DIFF
--- a/src/renderer/components/SettingsSection/Developer.tsx
+++ b/src/renderer/components/SettingsSection/Developer.tsx
@@ -48,7 +48,7 @@ export const DeveloperSettings: React.FC = () => {
               <input
                 className="ml-2"
                 type="button"
-                value="Reset do default"
+                value="Reset to default"
                 onClick={() => setConfigDownloadUrl(packageInfo.configUrls.production)}
               />
             </div>

--- a/src/renderer/components/SettingsSection/Developer.tsx
+++ b/src/renderer/components/SettingsSection/Developer.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useCallback, useEffect, useState } from 'react';
 import { useSetting } from 'renderer/rendererSettings';
 import { Toggle } from 'renderer/components/Toggle';
+import * as packageInfo from '../../../../package.json';
 
 const SettingsItem: FC<{ name: string }> = ({ name, children }) => (
   <div className="flex flex-row items-center justify-between py-3.5">
@@ -43,6 +44,12 @@ export const DeveloperSettings: React.FC = () => {
                 onChange={(event) => setConfigDownloadUrl(event.target.value)}
                 onBlur={() => validateUrl()}
                 size={50}
+              />
+              <input
+                className="ml-2"
+                type="button"
+                value="Reset do default"
+                onClick={() => setConfigDownloadUrl(packageInfo.configUrls.production)}
               />
             </div>
           </SettingsItem>


### PR DESCRIPTION
## Summary of Changes
This adds a "Reset to default" button for the Configuration Download URL in the Developer Settings for developers convenience

## Screenshots
![image](https://github.com/user-attachments/assets/910feee1-f091-450d-9800-e74be3c4f7dd)