### PR TITLE
fix: handle invalid manifest.json files in checkIncompatibleAddOns function

### DIFF
--- a/src/renderer/utils/IncompatibleAddOnsCheck.ts
+++ b/src/renderer/utils/IncompatibleAddOnsCheck.ts
@@ -29,30 +29,34 @@ export class IncompatibleAddOnsCheck {
           const dirEntries = fs.readdirSync(filePath);
 
           if (dirEntries.includes(manifestFileName)) {
-            const manifest = JSON.parse(fs.readFileSync(path.join(filePath, manifestFileName), 'utf8'));
+            try {
+              const manifest = JSON.parse(fs.readFileSync(path.join(filePath, manifestFileName), 'utf8'));
 
-            for (const item of addon.incompatibleAddons) {
-              // This checks the configuration item properties (if set) against the manifest.json file
-              // entry property values. If all properties match, the add-on is considered incompatible.
-              // packageVersion syntax follows: https://www.npmjs.com/package/semver
-              // Future improvement would be to allow for regular expressions in the configuration item.
-              const titleMatches = !item.title || manifest.title === item.title;
-              const creatorMatches = !item.creator || manifest.creator === item.creator;
-              const packageVersionTargeted =
-                !item.packageVersion || semverSatisfies(manifest.package_version, item.packageVersion);
+              for (const item of addon.incompatibleAddons) {
+                // This checks the configuration item properties (if set) against the manifest.json file
+                // entry property values. If all properties match, the add-on is considered incompatible.
+                // packageVersion syntax follows: https://www.npmjs.com/package/semver
+                // Future improvement would be to allow for regular expressions in the configuration item.
+                const titleMatches = !item.title || manifest.title === item.title;
+                const creatorMatches = !item.creator || manifest.creator === item.creator;
+                const packageVersionTargeted =
+                    !item.packageVersion || semverSatisfies(manifest.package_version, item.packageVersion);
 
-              if (titleMatches && creatorMatches && packageVersionTargeted) {
-                // Also write this to the log as this info might be useful for support.
-                console.log(`Incompatible Add-On found: ${manifest.title}: ${item.description}`);
+                if (titleMatches && creatorMatches && packageVersionTargeted) {
+                  // Also write this to the log as this info might be useful for support.
+                  console.log(`Incompatible Add-On found: ${manifest.title}: ${item.description}`);
 
-                incompatibleAddons.push({
-                  title: item.title,
-                  creator: item.creator,
-                  packageVersion: item.packageVersion,
-                  folder: entry,
-                  description: item.description,
-                });
-              }
+                  incompatibleAddons.push({
+                    title: item.title,
+                    creator: item.creator,
+                    packageVersion: item.packageVersion,
+                    folder: entry,
+                    description: item.description,
+                  });
+                }
+              }              
+            } catch (e) {
+              console.warn(`Failed to read or parse manifest.json in ${filePath}:`, e.message);
             }
           }
         }

--- a/src/renderer/utils/IncompatibleAddOnsCheck.ts
+++ b/src/renderer/utils/IncompatibleAddOnsCheck.ts
@@ -40,7 +40,7 @@ export class IncompatibleAddOnsCheck {
                 const titleMatches = !item.title || manifest.title === item.title;
                 const creatorMatches = !item.creator || manifest.creator === item.creator;
                 const packageVersionTargeted =
-                    !item.packageVersion || semverSatisfies(manifest.package_version, item.packageVersion);
+                  !item.packageVersion || semverSatisfies(manifest.package_version, item.packageVersion);
 
                 if (titleMatches && creatorMatches && packageVersionTargeted) {
                   // Also write this to the log as this info might be useful for support.
@@ -54,7 +54,7 @@ export class IncompatibleAddOnsCheck {
                     description: item.description,
                   });
                 }
-              }              
+              }
             } catch (e) {
               console.warn(`Failed to read or parse manifest.json in ${filePath}:`, e.message);
             }


### PR DESCRIPTION
<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes

- Error Handling for manifest.json Parsing:
Added a try-catch block to handle cases where `manifest.json` is invalid or unreadable.
Prevented the function from crashing due to syntax errors or unexpected tokens in manifest.json.

- Logging Improvements:
Implemented `console.warn` to log issues with specific `manifest.json` files for debugging purposes.

- Resilience Enhancements:
Ensured the function gracefully continues processing other directories even if a corrupt `manifest.json` is encountered.

These changes improve the reliability and robustness of the `checkIncompatibleAddOns` function.

## Screenshots (if necessary)
Before:
![grafik](https://github.com/user-attachments/assets/41705d21-ba29-479e-aa3a-b46166127aa9)

After:
![grafik](https://github.com/user-attachments/assets/162ec5de-88b1-45f0-afae-3ca6d762ba1d)


## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
