### PR TITLE
fix: Avoid caching of config file

### DIFF
--- a/src/renderer/utils/InstallerConfiguration.ts
+++ b/src/renderer/utils/InstallerConfiguration.ts
@@ -401,7 +401,8 @@ export class InstallerConfiguration {
   }
 
   private static async fetchConfigurationFromCdn(): Promise<Configuration> {
-    const url = settings.get('mainSettings.configDownloadUrl') as string;
+    const url = `${settings.get('mainSettings.configDownloadUrl') as string}?cache-killer=${Math.random()}`;
+
     console.log('Obtaining configuration from CDN (%s)', url);
     return await fetch(url)
       .then((res) => res.blob())


### PR DESCRIPTION
## Summary of Changes
As it sometimes takes forever for users to see new configs we should make sure the config file is not cached. 

I tried with a http header which didn't work. So added a cache-killer parameter. 

## Additional context
https://discord.com/channels/738864299392630914/846470774361161808/1307387181605847120

Discord username (if different from GitHub): cdr_maverick
