### PR TITLE
refactor: enhance configuration url handle

### DIFF
--- a/src/renderer/components/SettingsSection/Developer.tsx
+++ b/src/renderer/components/SettingsSection/Developer.tsx
@@ -2,6 +2,9 @@ import React, { FC, useCallback, useEffect, useState } from 'react';
 import { useSetting } from 'renderer/rendererSettings';
 import { Toggle } from 'renderer/components/Toggle';
 import * as packageInfo from '../../../../package.json';
+import { Button, ButtonType } from 'renderer/components/Button';
+import { ipcRenderer } from 'electron';
+import channels from 'common/channels';
 
 const SettingsItem: FC<{ name: string }> = ({ name, children }) => (
   <div className="flex flex-row items-center justify-between py-3.5">
@@ -45,12 +48,20 @@ export const DeveloperSettings: React.FC = () => {
                 onBlur={() => validateUrl()}
                 size={50}
               />
-              <input
-                className="ml-2"
-                type="button"
-                value="Reset to default"
+              <Button
+                type={ButtonType.Neutral}
+                className="ml-2 h-fit min-h-10 text-lg"
+                onClick={() => ipcRenderer.send(channels.window.reload)}
+              >
+                Reload Installer
+              </Button>
+              <Button
+                type={ButtonType.Neutral}
+                className="ml-2 h-fit min-h-10 text-lg"
                 onClick={() => setConfigDownloadUrl(packageInfo.configUrls.production)}
-              />
+              >
+                Reset to default
+              </Button>
             </div>
           </SettingsItem>
           <SettingsItem name="Force Use Local Configuration">


### PR DESCRIPTION
<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes

This update enhances the "Developer Settings" UI by introducing a new Reload Installer button for reloading the application and replacing the existing Reset to Default button with a styled Button component, ensuring a consistent and modern user experience. The changes also improve layout alignment and maintain existing functionality.

### Changelog

#### Added
- **Reload Installer Button**:
  - Introduced a new button using the `Button` component.
  - Styled with `ButtonType.Neutral` and class attributes (`ml-2 h-fit min-h-10 text-lg`) for consistent UI.
  - On click, sends the `ipcRenderer.send(channels.window.reload)` command to reload the installer.

#### Modified
- **Reset to Default Button**:
  - Replaced the existing `<input type="button">` element with the `Button` component.
  - Preserves functionality to reset the "Configuration Download URL" to `packageInfo.configUrls.production`.
  - Styled using `ButtonType.Neutral` and class attributes (`ml-2 h-fit min-h-10 text-lg`) for uniformity.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->
Before:

![381765242-910feee1-f091-450d-9800-e74be3c4f7dd](https://github.com/user-attachments/assets/ba8413be-f5d4-4cc6-9acf-b4dc75b37e9a)

After:
![grafik](https://github.com/user-attachments/assets/df9f531d-eb99-40ac-816c-edb6d592a075)

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
