### PR TITLE
chore: update copyright year

### DIFF
--- a/src/renderer/components/SettingsSection/About.tsx
+++ b/src/renderer/components/SettingsSection/About.tsx
@@ -52,7 +52,7 @@ export const AboutSettings: FC = () => {
       </div>
 
       <div className="flex flex-col justify-center">
-        <span className="text-2xl">Copyright (c) 2020-2022 FlyByWire Simulations and its contributors</span>
+        <span className="text-2xl">Copyright (c) 2020-2024 FlyByWire Simulations and its contributors</span>
         <span className="text-2xl">Licensed under the GNU General Public License Version 3</span>
 
         <span className="mt-4 text-2xl text-gray-200">


### PR DESCRIPTION
## Summary of Changes
Updates the year in the Copyright text on the About page. 

Discord username (if different from GitHub): cdr_maverick
