### PR TITLE
fix: match alternative urls for installed track

### DIFF
--- a/.github/CHANGELOG.yaml
+++ b/.github/CHANGELOG.yaml
@@ -9,16 +9,21 @@
 
 
 releases:
+  - name: 3.7.1
+    changes:
+      - title: Fix detection of old install sources
+        categories: [Logic]
+        authors: [FoxtrotSierra]
   - name: 3.7.0
     changes:
       - title: Add Linux compatibility
         categories: [Core]
-        authors: [FoxtotSierra]
+        authors: [FoxtrotSierra]
   - name: 3.6.0
     changes:
       - title: Add Quality Assurance functionality
         categories: [Core]
-        authors: [FoxtotSierra]
+        authors: [FoxtrotSierra]
       - title: Fixed "Don't show this again" toggle button
         categories: [UI]
         authors: [JoaoOliveira85]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fbw-installer",
-  "version": "3.7.0-dev.1",
+  "version": "3.7.1-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fbw-installer",
-      "version": "3.7.0-dev.1",
+      "version": "3.7.1-dev.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@flybywiresim/fragmenter": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fbw-installer",
   "productName": "FlyByWire Installer",
-  "version": "3.7.0-dev.1",
+  "version": "3.7.1-dev.1",
   "description": "Desktop application to install and customize FlyByWire addons",
   "author": {
     "name": "FlyByWire Simulations",

--- a/src/renderer/utils/InstallManager.tsx
+++ b/src/renderer/utils/InstallManager.tsx
@@ -665,7 +665,9 @@ export class InstallManager {
       return null;
     }
 
-    const matchingTrack = addon.tracks.find((it) => it.url === install.source);
+    const matchingTrack = addon.tracks.find(
+      (it) => it.url === install.source || it.alternativeUrls?.includes(install.source),
+    );
 
     if (!matchingTrack) {
       return null;


### PR DESCRIPTION
<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->
- fixes functionality that matches alternative urls to installed tracks, which was lost some time ago

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
